### PR TITLE
Fix player bouncing on ground

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -168,13 +168,15 @@ fn move_vertical(
     plyr: &mut Player,
     dt: f32,
 ) {
-    // reset grounded so each frame re‑evaluates contact
-    plyr.grounded = false;
+    // re-check ground contact before applying gravity
+    apply_ground_snap(spatial, entity, tf, plyr);
 
-    if !plyr.grounded {
-        plyr.vertical_vel -= params.gravity * dt;
-    } else {
+    if plyr.grounded {
+        // player was grounded last frame, so don't apply gravity
         plyr.vertical_vel = 0.0;
+    } else {
+        // apply gravity when falling
+        plyr.vertical_vel -= params.gravity * dt;
     }
     tf.translation.y += plyr.vertical_vel * dt;
     resolve_vertical_collision(spatial, entity, col, tf, plyr);


### PR DESCRIPTION
## Summary
- prevent endless bouncing by rechecking ground contact before applying gravity
- only apply gravity when not grounded

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68618444828c8321b52911ae9593f00e