### PR TITLE
Add weapon energy system

### DIFF
--- a/src/debug_ui.rs
+++ b/src/debug_ui.rs
@@ -62,6 +62,7 @@ fn debug_ui(
             ui.label(format!("speed        : {:>6.2}", p.speed));
             ui.label(format!("vertical_vel : {:>6.2}", p.vertical_vel));
             ui.label(format!("yaw (rad)    : {:>6.2}", p.yaw));
+            ui.label(format!("weapon_energy: {:>6.2}", p.weapon_energy));
             ui.label(format!("pos          : {:.1?}", tf.translation));
             ui.separator();
         }
@@ -81,5 +82,6 @@ fn handle_respawn(
         plyr.speed = 0.0;
         plyr.vertical_vel = 0.0;
         plyr.fire_timer = 0.0;
+        plyr.weapon_energy = 1.0;
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -21,6 +21,7 @@ pub struct Player {
     pub half_extents: Vec3,
     pub grounded: bool,
     pub fire_timer: f32,
+    pub weapon_energy: f32,
 }
 
 pub struct PlayerControlPlugin;
@@ -244,6 +245,7 @@ fn fall_reset_system(mut q: Query<(&mut Transform, &mut Player)>) {
             plyr.grounded = false;
             plyr.yaw = RESPAWN_YAW;
             plyr.fire_timer = 0.0;
+            plyr.weapon_energy = 1.0;
         }
     }
 }

--- a/src/weapons.rs
+++ b/src/weapons.rs
@@ -29,11 +29,17 @@ fn player_fire_system(
     mut players: Query<(&Transform, &mut Player)>,
 ) {
     let dt = time.delta_secs();
+    let recharge_rate = dt / 5.0;
+    let fire_cost = 1.0 / (params.fire_rate * 3.0);
     for (tf, mut plyr) in &mut players {
         if plyr.fire_timer > 0.0 {
             plyr.fire_timer -= dt;
         }
+        plyr.weapon_energy = (plyr.weapon_energy + recharge_rate).min(1.0);
         if keys.pressed(KeyCode::Space) && plyr.fire_timer <= 0.0 {
+            if plyr.weapon_energy < fire_cost {
+                continue;
+            }
             let forward = tf.rotation * Vec3::Z;
             let pos = tf.translation + forward * (plyr.half_extents.z + 0.6);
             let mesh = meshes.add(Cuboid::new(0.05, 0.05, 0.3));
@@ -57,6 +63,7 @@ fn player_fire_system(
                     life: LASER_LIFETIME,
                 });
             plyr.fire_timer = 1.0 / params.fire_rate.max(f32::EPSILON);
+            plyr.weapon_energy -= fire_cost;
         }
     }
 }

--- a/src/weapons.rs
+++ b/src/weapons.rs
@@ -29,8 +29,8 @@ fn player_fire_system(
     mut players: Query<(&Transform, &mut Player)>,
 ) {
     let dt = time.delta_secs();
-    let recharge_rate = dt / 5.0;
-    let fire_cost = 1.0 / (params.fire_rate * 3.0);
+    let recharge_rate = dt / 8.0;
+    let fire_cost = 1.0 / (params.fire_rate * 1.0);
     for (tf, mut plyr) in &mut players {
         if plyr.fire_timer > 0.0 {
             plyr.fire_timer -= dt;
@@ -64,6 +64,7 @@ fn player_fire_system(
                 });
             plyr.fire_timer = 1.0 / params.fire_rate.max(f32::EPSILON);
             plyr.weapon_energy -= fire_cost;
+            info!("Fired laser! Energy left: {}", plyr.weapon_energy);
         }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -54,5 +54,6 @@ fn setup_world(
             half_extents: Vec3::splat(0.25),
             grounded: false,
             fire_timer: 0.0,
+            weapon_energy: 1.0,
         });
 }


### PR DESCRIPTION
## Summary
- implement energy for player weapons
- recharge weapon energy over time
- show weapon energy in debug UI

## Testing
- `cargo check` *(fails: Tests are disabled and environment might not allow build)*

------
https://chatgpt.com/codex/tasks/task_e_6863009c1b8c832184074afd6c1aa516