### PR TITLE
Switch target hits to physics raycasts

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -72,7 +72,7 @@ fn laser_hit_system(
         if let Some(hit) = spatial.cast_ray(start, dir, dist, true, &filter) {
             if let Ok((target_entity, mut target)) = targets.get_mut(hit.entity) {
                 let normal = hit.normal;
-                let hit_pos = hit.point;
+                let hit_pos = start + dir.as_vec3() * hit.distance;
                 let new_hp = (target.hp - LASER_DAMAGE).max(0);
                 target.hp = new_hp;
                 if new_hp == 0 {


### PR DESCRIPTION
## Summary
- remove AABB based hit detection
- use `SpatialQuery::cast_ray` so targets can use trimesh colliders
- simplify `Target` component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866b68d424c8321b095ccef709c286b