### PR TITLE
Disable continuous flight

### DIFF
--- a/src/debug_ui.rs
+++ b/src/debug_ui.rs
@@ -82,7 +82,6 @@ fn debug_ui(
             ui.heading(format!("Player {i}"));
             ui.label(format!("speed        : {:>6.2}", p.speed));
             ui.label(format!("vertical_vel : {:>6.2}", p.vertical_vel));
-            ui.label(format!("desired_alt  : {:>6.2}", p.desired_altitude));
             ui.label(format!("yaw (rad)    : {:>6.2}", p.yaw));
             ui.label(format!("weapon_energy: {:>6.2}", p.weapon_energy));
             ui.label(format!("pos          : {:.1?}", tf.translation));
@@ -104,7 +103,6 @@ fn handle_respawn(
         plyr.speed = 0.0;
         plyr.vertical_vel = 0.0;
         plyr.vertical_input = 0.0;
-        plyr.desired_altitude = 3.0;
         plyr.fire_timer = 0.0;
         plyr.weapon_energy = 1.0;
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -71,7 +71,7 @@ fn player_move_system(
         );
         for _ in 0..SUBSTEPS {
             move_horizontal(&spatial, &params, entity, &col, &mut tf, &mut plyr, dt);
-            move_vertical(&spatial, entity, &col, &mut tf, &mut plyr, dt);
+            move_vertical(&spatial, &params, entity, &col, &mut tf, &mut plyr, dt);
         }
     }
 }
@@ -187,6 +187,7 @@ fn slide(remaining: &mut Vec3, normal: Vec3, plyr: &mut Player, params: &GamePar
 
 fn move_vertical(
     spatial: &SpatialQuery,
+    params: &GameParams,
     entity: Entity,
     col: &Collider,
     tf: &mut Transform,

--- a/src/world.rs
+++ b/src/world.rs
@@ -51,7 +51,6 @@ fn setup_world(
             speed: 0.0,
             vertical_vel: 0.0,
             vertical_input: 0.0,
-            desired_altitude: 3.0,
             yaw: 0.0,
             half_extents: Vec3::splat(0.25),
             grounded: false,


### PR DESCRIPTION
## Summary
- remove flight-specific constants and altitude field
- update player input so W/S gives single impulse
- apply gravity each frame so the player rests on the ground
- adjust debug UI and world setup for updated Player

## Testing
- `cargo check` *(fails: command not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6866c8c407248321874c1431ab64ee78