### PR TITLE
Adjust slope pitch handling

### DIFF
--- a/src/debug_ui.rs
+++ b/src/debug_ui.rs
@@ -65,6 +65,7 @@ fn debug_ui(
         slider!(cam_height, 0.0..=20.0);
         slider!(cam_lerp, 0.0..=1.0);
         slider!(cam_rot_lerp, 0.0..=1.0);
+        slider!(ground_align_lerp, 0.0..=1.0);
         slider!(look_ahead, 0.0..=20.0);
         slider!(mini_map_size, 0.0..=100.0);
         slider!(mini_map_height, 0.0..=200.0);

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -13,6 +13,7 @@ pub struct GameParams {
     pub cam_height: f32,
     pub cam_lerp: f32,
     pub cam_rot_lerp: f32,
+    pub ground_align_lerp: f32,
     pub look_ahead: f32,
     pub mini_map_size: f32,
     pub mini_map_height: f32,
@@ -40,6 +41,7 @@ impl Default for GameParams {
             cam_height: 1.9,
             cam_lerp: 0.65,
             cam_rot_lerp: 0.45,
+            ground_align_lerp: 0.1,
             look_ahead: 2.0,
             mini_map_size: 300.0,
             mini_map_height: 400.0,
@@ -49,7 +51,7 @@ impl Default for GameParams {
             collision_damping: 0.4,
             slope_damping: 0.2,
             slope_ease: 0.5,
-            bounce_factor: 0.05,
+            bounce_factor: 0.02,
             socket_url: "wss://535rf3b3kk.execute-api.us-east-1.amazonaws.com/$default".to_string(),
         }
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -78,11 +78,12 @@ fn player_move_system(
 
 fn player_orientation_system(
     spatial: SpatialQuery,
+    params: Res<GameParams>,
     mut q: Query<(Entity, &mut Transform, &mut Player)>,
 ) {
     for (entity, mut tf, mut plyr) in &mut q {
         apply_ground_snap(&spatial, entity, &mut tf, &mut plyr);
-        orient_to_ground(&spatial, entity, &mut tf, &plyr);
+        orient_to_ground(&spatial, &params, entity, &mut tf, &plyr);
     }
 }
 
@@ -256,7 +257,13 @@ fn apply_ground_snap(
     plyr.grounded = grounded_now;
 }
 
-fn orient_to_ground(spatial: &SpatialQuery, entity: Entity, tf: &mut Transform, plyr: &Player) {
+fn orient_to_ground(
+    spatial: &SpatialQuery,
+    params: &GameParams,
+    entity: Entity,
+    tf: &mut Transform,
+    plyr: &Player,
+) {
     let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
     let ground_n = spatial
         .cast_ray(
@@ -270,8 +277,7 @@ fn orient_to_ground(spatial: &SpatialQuery, entity: Entity, tf: &mut Transform, 
         .unwrap_or(Vec3::Y);
     let yaw_rot = Quat::from_rotation_y(plyr.yaw);
     let target = Quat::from_rotation_arc(Vec3::Y, ground_n) * yaw_rot;
-    const ROT_SMOOTH: f32 = 0.2;
-    tf.rotation = tf.rotation.slerp(target, ROT_SMOOTH);
+    tf.rotation = tf.rotation.slerp(target, params.ground_align_lerp);
 }
 
 fn fall_reset_system(mut q: Query<(&mut Transform, &mut Player)>) {


### PR DESCRIPTION
## Summary
- expose rotation smoothing via `ground_align_lerp` in `GameParams`
- lower default `bounce_factor`
- use the new smoothing parameter when aligning the player to the ground
- hook parameter into debug UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866cb946380832186d02d5ecc1414ee