### PR TITLE
Add vehicle into main world

### DIFF
--- a/examples/vehicle_demo.rs
+++ b/examples/vehicle_demo.rs
@@ -1,0 +1,30 @@
+use bevy::prelude::*;
+use avian3d::prelude::*;
+
+use game_demo::vehicle_plugin::VehiclePlugin;
+use game_demo::vehicle::spawn_vehicle;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, PhysicsPlugins::default()))
+        .insert_resource(Gravity(Vec3::new(0.0, -9.81, 0.0)))
+        .add_plugins(VehiclePlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn(DirectionalLight::default());
+    let ground = meshes.add(Cuboid::new(50.0, 1.0, 50.0));
+    commands
+        .spawn(Mesh3d(ground))
+        .insert(MeshMaterial3d(materials.add(Color::srgb(0.3, 0.7, 0.3))))
+        .insert(Transform::from_xyz(0.0, -1.0, 0.0))
+        .insert(RigidBody::Static)
+        .insert(Collider::cuboid(50.0, 1.0, 50.0));
+    spawn_vehicle(&mut commands, Vec3::new(0.0, 2.0, 0.0));
+}

--- a/examples/vehicle_demo.rs
+++ b/examples/vehicle_demo.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use avian3d::prelude::*;
 
 use game_demo::vehicle_plugin::VehiclePlugin;
-use game_demo::vehicle::spawn_vehicle;
+use game_demo::vehicle::{spawn_vehicle, VehicleTuning};
 
 fn main() {
     App::new()
@@ -17,6 +17,7 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    tuning: Res<VehicleTuning>,
 ) {
     commands.spawn(DirectionalLight::default());
     let ground = meshes.add(Cuboid::new(50.0, 1.0, 50.0));
@@ -26,5 +27,5 @@ fn setup(
         .insert(Transform::from_xyz(0.0, -1.0, 0.0))
         .insert(RigidBody::Static)
         .insert(Collider::cuboid(50.0, 1.0, 50.0));
-    spawn_vehicle(&mut commands, Vec3::new(0.0, 2.0, 0.0));
+    spawn_vehicle(&mut commands, Vec3::new(0.0, 2.0, 0.0), &tuning);
 }

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -1,0 +1,36 @@
+use bevy::prelude::*;
+use avian3d::prelude::*;
+
+use crate::vehicle::{Vehicle, Wheel};
+
+pub fn vehicle_input_system(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut q: Query<&mut LinearVelocity, With<Vehicle>>,
+) {
+    for mut vel in &mut q {
+        if keys.pressed(KeyCode::ArrowUp) {
+            vel.z += 10.0;
+        }
+        if keys.pressed(KeyCode::ArrowDown) {
+            vel.z -= 10.0;
+        }
+        if keys.pressed(KeyCode::Space) {
+            vel.x *= 0.5;
+            vel.z *= 0.5;
+        }
+    }
+}
+
+pub fn wheel_steer_system(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut q: Query<&mut Transform, With<Wheel>>,
+) {
+    for mut tf in &mut q {
+        if keys.pressed(KeyCode::ArrowLeft) {
+            tf.rotation *= Quat::from_rotation_y(0.02);
+        }
+        if keys.pressed(KeyCode::ArrowRight) {
+            tf.rotation *= Quat::from_rotation_y(-0.02);
+        }
+    }
+}

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -7,17 +7,10 @@ pub fn vehicle_input_system(
     keys: Res<ButtonInput<KeyCode>>,
     mut q: Query<&mut LinearVelocity, With<Vehicle>>,
 ) {
+    let a = (keys.pressed(KeyCode::ArrowUp) as i32 - keys.pressed(KeyCode::ArrowDown) as i32) as f32 * 10.0;
     for mut vel in &mut q {
-        if keys.pressed(KeyCode::ArrowUp) {
-            vel.z += 10.0;
-        }
-        if keys.pressed(KeyCode::ArrowDown) {
-            vel.z -= 10.0;
-        }
-        if keys.pressed(KeyCode::Space) {
-            vel.x *= 0.5;
-            vel.z *= 0.5;
-        }
+        vel.z += a;
+        if keys.pressed(KeyCode::Space) { vel.x *= 0.5; vel.z *= 0.5; }
     }
 }
 
@@ -25,12 +18,8 @@ pub fn wheel_steer_system(
     keys: Res<ButtonInput<KeyCode>>,
     mut q: Query<&mut Transform, With<Wheel>>,
 ) {
-    for mut tf in &mut q {
-        if keys.pressed(KeyCode::ArrowLeft) {
-            tf.rotation *= Quat::from_rotation_y(0.02);
-        }
-        if keys.pressed(KeyCode::ArrowRight) {
-            tf.rotation *= Quat::from_rotation_y(-0.02);
-        }
+    let steer = if keys.pressed(KeyCode::ArrowLeft) { 0.02 } else if keys.pressed(KeyCode::ArrowRight) { -0.02 } else { 0.0 };
+    if steer != 0.0 {
+        for mut tf in &mut q { tf.rotation *= Quat::from_rotation_y(steer); }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,7 @@ pub mod lap_timer;
 pub mod socket_client;
 pub mod chat;
 pub mod hp_text;
+pub mod vehicle;
+pub mod vehicle_plugin;
+pub mod suspension;
+pub mod controls;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use game_demo::camera::CameraPlugin;
 use game_demo::debug_ui::DebugUiPlugin;
 use game_demo::hud::HudPlugin;
 use game_demo::globals::GameParams;
-use game_demo::input::PlayerControlPlugin;
+use game_demo::vehicle_plugin::VehiclePlugin;
 use game_demo::weapons::WeaponPlugin;
 use game_demo::weapon_hud::WeaponHudPlugin;
 use game_demo::minimap::MiniMapPlugin;
@@ -30,7 +30,7 @@ fn main() {
             TargetsPlugin,
             GoalsPlugin,
             SkyDomePlugin,
-            PlayerControlPlugin,
+            VehiclePlugin,
             WeaponPlugin,
             CameraPlugin,
             MiniMapPlugin,

--- a/src/suspension.rs
+++ b/src/suspension.rs
@@ -1,0 +1,26 @@
+use bevy::prelude::*;
+use avian3d::prelude::*;
+
+use crate::vehicle::{Wheel, VehicleTuning};
+
+pub fn suspension_system(
+    spatial: SpatialQuery,
+    mut wheels: Query<(&mut LinearVelocity, &Transform, &Wheel)>,
+    tuning: Res<VehicleTuning>,
+) {
+    for (mut vel, tf, wheel) in &mut wheels {
+        let start = tf.translation + Vec3::Y * wheel.radius;
+        if let Some(hit) = spatial.cast_ray(
+            start,
+            Dir3::NEG_Y,
+            tuning.suspension.max_travel + wheel.radius,
+            false,
+            &SpatialQueryFilter::default(),
+        ) {
+            let disp = tuning.suspension.max_travel + wheel.radius - hit.time_of_impact;
+            let spring = tuning.suspension.spring_k * disp;
+            let damp = tuning.suspension.damping_c * vel.y;
+            vel.y += (spring - damp) * 0.016;
+        }
+    }
+}

--- a/src/suspension.rs
+++ b/src/suspension.rs
@@ -3,24 +3,26 @@ use avian3d::prelude::*;
 
 use crate::vehicle::{Wheel, VehicleTuning};
 
+fn apply_suspension(
+    start: Vec3,
+    vel: &mut LinearVelocity,
+    spatial: &SpatialQuery,
+    params: &SuspensionParams,
+    radius: f32,
+) {
+    if let Some(hit) = spatial.cast_ray(start, Dir3::NEG_Y, params.max_travel + radius, false, &SpatialQueryFilter::default()) {
+        let disp = params.max_travel + radius - hit.distance;
+        let force = params.spring_k * disp - params.damping_c * vel.y;
+        vel.y += force * 0.016;
+    }
+}
+
 pub fn suspension_system(
     spatial: SpatialQuery,
     mut wheels: Query<(&mut LinearVelocity, &Transform, &Wheel)>,
     tuning: Res<VehicleTuning>,
 ) {
     for (mut vel, tf, wheel) in &mut wheels {
-        let start = tf.translation + Vec3::Y * wheel.radius;
-        if let Some(hit) = spatial.cast_ray(
-            start,
-            Dir3::NEG_Y,
-            tuning.suspension.max_travel + wheel.radius,
-            false,
-            &SpatialQueryFilter::default(),
-        ) {
-            let disp = tuning.suspension.max_travel + wheel.radius - hit.distance;
-            let spring = tuning.suspension.spring_k * disp;
-            let damp = tuning.suspension.damping_c * vel.y;
-            vel.y += (spring - damp) * 0.016;
-        }
+        apply_suspension(tf.translation + Vec3::Y * wheel.radius, &mut vel, &spatial, &tuning.suspension, wheel.radius);
     }
 }

--- a/src/suspension.rs
+++ b/src/suspension.rs
@@ -1,8 +1,7 @@
 use bevy::prelude::*;
 use avian3d::prelude::*;
 
-use crate::vehicle::{Vehicle, Wheel, VehicleTuning, SuspensionParams};
-use bevy::prelude::Parent;
+use crate::vehicle::{SuspensionParams, Vehicle, VehicleTuning, Wheel};
 
 fn apply_suspension(
     start: Vec3,
@@ -22,13 +21,23 @@ fn apply_suspension(
 
 pub fn suspension_system(
     spatial: SpatialQuery,
-    mut wheels: Query<(&mut LinearVelocity, &GlobalTransform, &Wheel, &Parent)>,
-    mut vehicles: Query<&mut LinearVelocity, With<Vehicle>>,
+    mut set: ParamSet<(
+        Query<(&mut LinearVelocity, &GlobalTransform, &Wheel, &Parent)>,
+        Query<&mut LinearVelocity, With<Vehicle>>,
+    )>,
     tuning: Res<VehicleTuning>,
 ) {
-    for (mut vel, tf, wheel, parent) in &mut wheels {
+    let mut vehicles = set.p1();
+    for (mut vel, tf, wheel, parent) in &mut set.p0() {
         if let Ok(mut car_vel) = vehicles.get_mut(parent.get()) {
-            apply_suspension(tf.translation() + Vec3::Y * wheel.radius, &mut vel, &mut car_vel, &spatial, &tuning.suspension, wheel.radius);
+            apply_suspension(
+                tf.translation() + Vec3::Y * wheel.radius,
+                &mut vel,
+                &mut car_vel,
+                &spatial,
+                &tuning.suspension,
+                wheel.radius,
+            );
         }
     }
 }

--- a/src/suspension.rs
+++ b/src/suspension.rs
@@ -17,7 +17,7 @@ pub fn suspension_system(
             false,
             &SpatialQueryFilter::default(),
         ) {
-            let disp = tuning.suspension.max_travel + wheel.radius - hit.time_of_impact;
+            let disp = tuning.suspension.max_travel + wheel.radius - hit.distance;
             let spring = tuning.suspension.spring_k * disp;
             let damp = tuning.suspension.damping_c * vel.y;
             vel.y += (spring - damp) * 0.016;

--- a/src/suspension.rs
+++ b/src/suspension.rs
@@ -2,42 +2,47 @@ use bevy::prelude::*;
 use avian3d::prelude::*;
 
 use crate::vehicle::{SuspensionParams, Vehicle, VehicleTuning, Wheel};
+use bevy::prelude::ChildOf;
 
-fn apply_suspension(
+fn calc_suspension(
     start: Vec3,
-    wheel_vel: &mut LinearVelocity,
-    chassis_vel: &mut LinearVelocity,
+    vel: &mut LinearVelocity,
     spatial: &SpatialQuery,
     params: &SuspensionParams,
     radius: f32,
-) {
-    if let Some(hit) = spatial.cast_ray(start, Dir3::NEG_Y, params.max_travel + radius, false, &SpatialQueryFilter::default()) {
+) -> Option<f32> {
+    spatial.cast_ray(start, Dir3::NEG_Y, params.max_travel + radius, false, &SpatialQueryFilter::default()).map(|hit| {
         let disp = params.max_travel + radius - hit.distance;
-        let force = params.spring_k * disp - params.damping_c * wheel_vel.y;
-        wheel_vel.y += force * 0.016;
-        chassis_vel.y += force * 0.016;
-    }
+        let force = params.spring_k * disp - params.damping_c * vel.y;
+        vel.y += force * 0.016;
+        force
+    })
 }
 
 pub fn suspension_system(
     spatial: SpatialQuery,
     mut set: ParamSet<(
-        Query<(&mut LinearVelocity, &GlobalTransform, &Wheel, &Parent)>,
+        Query<(&mut LinearVelocity, &GlobalTransform, &Wheel, &ChildOf<Vehicle>)>,
         Query<&mut LinearVelocity, With<Vehicle>>,
     )>,
     tuning: Res<VehicleTuning>,
 ) {
-    let mut vehicles = set.p1();
+    let mut forces = Vec::new();
     for (mut vel, tf, wheel, parent) in &mut set.p0() {
-        if let Ok(mut car_vel) = vehicles.get_mut(parent.get()) {
-            apply_suspension(
-                tf.translation() + Vec3::Y * wheel.radius,
-                &mut vel,
-                &mut car_vel,
-                &spatial,
-                &tuning.suspension,
-                wheel.radius,
-            );
+        if let Some(force) = calc_suspension(
+            tf.translation() + Vec3::Y * wheel.radius,
+            &mut vel,
+            &spatial,
+            &tuning.suspension,
+            wheel.radius,
+        ) {
+            forces.push((parent.get(), force));
+        }
+    }
+
+    for (vehicle_entity, force) in forces {
+        if let Ok(mut car_vel) = set.p1().get_mut(vehicle_entity) {
+            car_vel.y += force * 0.016;
         }
     }
 }

--- a/src/suspension.rs
+++ b/src/suspension.rs
@@ -1,28 +1,33 @@
 use bevy::prelude::*;
 use avian3d::prelude::*;
 
-use crate::vehicle::{Wheel, VehicleTuning};
+use crate::vehicle::{Vehicle, Wheel, VehicleTuning};
 
 fn apply_suspension(
     start: Vec3,
-    vel: &mut LinearVelocity,
+    wheel_vel: &mut LinearVelocity,
+    chassis_vel: &mut LinearVelocity,
     spatial: &SpatialQuery,
     params: &SuspensionParams,
     radius: f32,
 ) {
     if let Some(hit) = spatial.cast_ray(start, Dir3::NEG_Y, params.max_travel + radius, false, &SpatialQueryFilter::default()) {
         let disp = params.max_travel + radius - hit.distance;
-        let force = params.spring_k * disp - params.damping_c * vel.y;
-        vel.y += force * 0.016;
+        let force = params.spring_k * disp - params.damping_c * wheel_vel.y;
+        wheel_vel.y += force * 0.016;
+        chassis_vel.y += force * 0.016;
     }
 }
 
 pub fn suspension_system(
     spatial: SpatialQuery,
-    mut wheels: Query<(&mut LinearVelocity, &Transform, &Wheel)>,
+    mut wheels: Query<(&mut LinearVelocity, &GlobalTransform, &Wheel, &Parent)>,
+    mut vehicles: Query<&mut LinearVelocity, With<Vehicle>>,
     tuning: Res<VehicleTuning>,
 ) {
-    for (mut vel, tf, wheel) in &mut wheels {
-        apply_suspension(tf.translation + Vec3::Y * wheel.radius, &mut vel, &spatial, &tuning.suspension, wheel.radius);
+    for (mut vel, tf, wheel, parent) in &mut wheels {
+        if let Ok(mut car_vel) = vehicles.get_mut(parent.get()) {
+            apply_suspension(tf.translation() + Vec3::Y * wheel.radius, &mut vel, &mut car_vel, &spatial, &tuning.suspension, wheel.radius);
+        }
     }
 }

--- a/src/suspension.rs
+++ b/src/suspension.rs
@@ -1,7 +1,8 @@
 use bevy::prelude::*;
 use avian3d::prelude::*;
 
-use crate::vehicle::{Vehicle, Wheel, VehicleTuning};
+use crate::vehicle::{Vehicle, Wheel, VehicleTuning, SuspensionParams};
+use bevy::prelude::Parent;
 
 fn apply_suspension(
     start: Vec3,

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use avian3d::prelude::*;
+use std::f32::consts::FRAC_PI_2;
 
 #[derive(Resource, Clone, Copy)]
 pub struct SuspensionParams {
@@ -122,7 +123,8 @@ pub fn spawn_vehicle(
                     drive: true,
                     ..Default::default()
                 },
-                transform: Transform::from_translation(pos + offset),
+                transform: Transform::from_translation(pos + offset)
+                    .with_rotation(Quat::from_rotation_z(FRAC_PI_2)),
                 ..Default::default()
             })
             .id();

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -83,7 +83,7 @@ impl Default for WheelBundle {
             wheel: Wheel { offset: Vec3::ZERO, radius: 0.75, width: 0.3, steer: false, drive: false },
             rb: RigidBody::Dynamic,
             collider: Collider::cylinder(0.75, 0.15),
-            transform: Transform::default(),
+            transform: Transform::from_rotation(Quat::from_rotation_z(-std::f32::consts::FRAC_PI_2)),
             global_transform: GlobalTransform::default(),
         }
     }
@@ -121,7 +121,11 @@ pub fn spawn_vehicle(
                     drive: true,
                     ..Default::default()
                 },
-                transform: Transform::from_translation(pos + offset),
+                transform: Transform {
+                    translation: pos + offset,
+                    rotation: Quat::from_rotation_z(-std::f32::consts::FRAC_PI_2),
+                    ..default()
+                },
                 ..Default::default()
             })
             .id();

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -10,7 +10,7 @@ pub struct SuspensionParams {
 
 impl Default for SuspensionParams {
     fn default() -> Self {
-        Self { spring_k: 20.0, damping_c: 5.0, max_travel: 0.75 }
+        Self { spring_k: 300.0, damping_c: 40.0, max_travel: 0.75 }
     }
 }
 
@@ -83,7 +83,7 @@ impl Default for WheelBundle {
             wheel: Wheel { offset: Vec3::ZERO, radius: 0.75, width: 0.3, steer: false, drive: false },
             rb: RigidBody::Dynamic,
             collider: Collider::cylinder(0.75, 0.15),
-            transform: Transform::from_rotation(Quat::from_rotation_z(-std::f32::consts::FRAC_PI_2)),
+            transform: Transform::default(),
             global_transform: GlobalTransform::default(),
         }
     }
@@ -110,8 +110,9 @@ pub fn spawn_vehicle(
 
     for offset in wheel_offsets {
         let axle = commands
-            .spawn((RigidBody::Dynamic, Transform::from_translation(pos + offset)))
+            .spawn((RigidBody::Dynamic, Transform::from_translation(pos + offset), GlobalTransform::default()))
             .id();
+        commands.entity(vehicle).push_children(&[axle]);
 
         let wheel = commands
             .spawn(WheelBundle {
@@ -121,14 +122,13 @@ pub fn spawn_vehicle(
                     drive: true,
                     ..Default::default()
                 },
-                transform: Transform {
-                    translation: pos + offset,
-                    rotation: Quat::from_rotation_z(-std::f32::consts::FRAC_PI_2),
-                    ..default()
-                },
+                transform: Transform::from_translation(pos + offset),
                 ..Default::default()
             })
             .id();
+
+        commands.entity(vehicle).push_children(&[wheel]);
+
 
         commands.spawn(
             PrismaticJoint::new(vehicle, axle)

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -31,7 +31,7 @@ pub struct Vehicle {
     pub drive_mode: DriveMode,
 }
 
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct Wheel {
     pub offset: Vec3,
     pub radius: f32,
@@ -112,7 +112,7 @@ pub fn spawn_vehicle(
         let axle = commands
             .spawn((RigidBody::Dynamic, Transform::from_translation(pos + offset), GlobalTransform::default()))
             .id();
-        commands.entity(vehicle).push_children(&[axle]);
+        commands.entity(vehicle).add_child(axle);
 
         let wheel = commands
             .spawn(WheelBundle {
@@ -127,7 +127,7 @@ pub fn spawn_vehicle(
             })
             .id();
 
-        commands.entity(vehicle).push_children(&[wheel]);
+        commands.entity(vehicle).add_child(wheel);
 
 
         commands.spawn(

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -1,0 +1,123 @@
+use bevy::prelude::*;
+use avian3d::prelude::*;
+
+#[derive(Resource, Clone, Copy)]
+pub struct SuspensionParams {
+    pub spring_k: f32,
+    pub damping_c: f32,
+    pub max_travel: f32,
+}
+
+impl Default for SuspensionParams {
+    fn default() -> Self {
+        Self { spring_k: 20.0, damping_c: 5.0, max_travel: 0.75 }
+    }
+}
+
+#[derive(Resource, Clone, Copy)]
+pub struct VehicleTuning {
+    pub com_offset: Vec3,
+    pub suspension: SuspensionParams,
+}
+
+impl Default for VehicleTuning {
+    fn default() -> Self {
+        Self { com_offset: Vec3::new(0.0, -0.3, 0.0), suspension: SuspensionParams::default() }
+    }
+}
+
+#[derive(Component)]
+pub struct Vehicle {
+    pub drive_mode: DriveMode,
+}
+
+#[derive(Component)]
+pub struct Wheel {
+    pub offset: Vec3,
+    pub radius: f32,
+    pub width: f32,
+    pub steer: bool,
+    pub drive: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum DriveMode {
+    Fwd,
+    Rwd,
+    Awd,
+}
+
+#[derive(Bundle)]
+pub struct VehicleBundle {
+    pub vehicle: Vehicle,
+    pub rb: RigidBody,
+    pub collider: Collider,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+}
+
+impl Default for VehicleBundle {
+    fn default() -> Self {
+        Self {
+            vehicle: Vehicle { drive_mode: DriveMode::Awd },
+            rb: RigidBody::Dynamic,
+            collider: Collider::cuboid(1.0, 0.5, 1.5),
+            transform: Transform::default(),
+            global_transform: GlobalTransform::default(),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct WheelBundle {
+    pub wheel: Wheel,
+    pub rb: RigidBody,
+    pub collider: Collider,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+}
+
+impl Default for WheelBundle {
+    fn default() -> Self {
+        Self {
+            wheel: Wheel { offset: Vec3::ZERO, radius: 0.75, width: 0.3, steer: false, drive: false },
+            rb: RigidBody::Dynamic,
+            collider: Collider::cylinder(0.75, 0.15),
+            transform: Transform::default(),
+            global_transform: GlobalTransform::default(),
+        }
+    }
+}
+
+pub fn spawn_vehicle(
+    commands: &mut Commands,
+    pos: Vec3,
+) -> Entity {
+    let vehicle = commands
+        .spawn(VehicleBundle { transform: Transform::from_translation(pos), ..Default::default() })
+        .id();
+
+    let wheel_offsets = [
+        Vec3::new(1.0, 0.0, 1.0),
+        Vec3::new(-1.0, 0.0, 1.0),
+        Vec3::new(1.0, 0.0, -1.0),
+        Vec3::new(-1.0, 0.0, -1.0),
+    ];
+
+    for offset in wheel_offsets {
+        commands.entity(vehicle).with_children(|parent| {
+            parent.spawn(WheelBundle {
+                wheel: Wheel {
+                    offset,
+                    steer: offset.z > 0.0,
+                    drive: true,
+                    ..Default::default()
+                },
+                transform: Transform::from_translation(offset),
+                ..Default::default()
+            });
+        });
+    }
+
+    vehicle
+}

--- a/src/vehicle_plugin.rs
+++ b/src/vehicle_plugin.rs
@@ -1,0 +1,40 @@
+use bevy::prelude::*;
+use avian3d::prelude::*;
+
+use crate::vehicle::{VehicleTuning};
+use crate::controls::{vehicle_input_system, wheel_steer_system};
+use crate::suspension::suspension_system;
+
+pub struct VehiclePlugin;
+
+impl Plugin for VehiclePlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(VehicleTuning::default())
+            .add_plugins((
+                VehiclePhysicsPlugin,
+                SuspensionPlugin,
+                WheelSteeringPlugin,
+            ));
+    }
+}
+
+pub struct VehiclePhysicsPlugin;
+impl Plugin for VehiclePhysicsPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(FixedUpdate, vehicle_input_system);
+    }
+}
+
+pub struct SuspensionPlugin;
+impl Plugin for SuspensionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(FixedUpdate, suspension_system);
+    }
+}
+
+pub struct WheelSteeringPlugin;
+impl Plugin for WheelSteeringPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(FixedUpdate, wheel_steer_system);
+    }
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,6 +1,7 @@
 use crate::input::Player;
+use crate::vehicle::spawn_vehicle;
 use avian3d::prelude::{Collider, ColliderConstructor, ColliderConstructorHierarchy};
-use avian3d::prelude::{LinearVelocity, RigidBody};
+use avian3d::prelude::RigidBody;
 use bevy::prelude::*;
 
 pub struct WorldPlugin;
@@ -13,8 +14,6 @@ impl Plugin for WorldPlugin {
 
 fn setup_world(
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
     asset_server: Res<AssetServer>,
 ) {
     let terrain: Handle<Scene> = asset_server.load("models/terrain.glb#Scene0");
@@ -39,21 +38,10 @@ fn setup_world(
         })
         .insert(Transform::from_xyz(5.0, 10.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y));
 
-    let mesh = meshes.add(Cuboid::new(0.25, 0.25, 0.25));
-    commands
-        .spawn(Mesh3d(mesh))
-        .insert(MeshMaterial3d(materials.add(Color::srgb(0.2, 0.8, 0.2))))
-        .insert(Transform::from_xyz(0.0, 3.0, 0.0))
-        .insert(RigidBody::Kinematic)
-        .insert(Collider::cuboid(0.25, 0.25, 0.25))
-        .insert(LinearVelocity::ZERO)
-        .insert(Player {
-            speed: 0.0,
-            vertical_vel: 0.0,
-            yaw: 0.0,
-            half_extents: Vec3::splat(0.25),
-            grounded: false,
-            fire_timer: 0.0,
-            weapon_energy: 1.0,
-        });
+    let vehicle = spawn_vehicle(&mut commands, Vec3::new(0.0, 3.0, 0.0));
+    commands.entity(vehicle).insert(Player {
+        half_extents: Vec3::splat(0.25),
+        weapon_energy: 1.0,
+        ..default()
+    });
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,5 @@
 use crate::input::Player;
-use crate::vehicle::spawn_vehicle;
+use crate::vehicle::{spawn_vehicle, VehicleTuning};
 use avian3d::prelude::{Collider, ColliderConstructor, ColliderConstructorHierarchy};
 use avian3d::prelude::RigidBody;
 use bevy::prelude::*;
@@ -15,6 +15,7 @@ impl Plugin for WorldPlugin {
 fn setup_world(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
+    tuning: Res<VehicleTuning>,
 ) {
     let terrain: Handle<Scene> = asset_server.load("models/terrain.glb#Scene0");
     commands
@@ -38,7 +39,7 @@ fn setup_world(
         })
         .insert(Transform::from_xyz(5.0, 10.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y));
 
-    let vehicle = spawn_vehicle(&mut commands, Vec3::new(0.0, 3.0, 0.0));
+    let vehicle = spawn_vehicle(&mut commands, Vec3::new(0.0, 3.0, 0.0), &tuning);
     commands.entity(vehicle).insert(Player {
         half_extents: Vec3::splat(0.25),
         weapon_energy: 1.0,

--- a/tests/vehicle_test.rs
+++ b/tests/vehicle_test.rs
@@ -1,0 +1,41 @@
+use bevy::prelude::*;
+use avian3d::prelude::*;
+use game_demo::vehicle_plugin::VehiclePlugin;
+use game_demo::vehicle::{VehicleBundle, Vehicle};
+
+#[test]
+fn vehicle_climbs_ramp() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, PhysicsPlugins::default()));
+    app.insert_resource(Gravity(Vec3::new(0.0, -9.81, 0.0)));
+    app.add_plugins(VehiclePlugin);
+
+    app.world.spawn((
+        Collider::cuboid(20.0, 1.0, 20.0),
+        Transform::from_xyz(0.0, -1.0, 0.0),
+        GlobalTransform::default(),
+        RigidBody::Static,
+    ));
+    app.world.spawn((
+        Collider::cuboid(10.0, 0.5, 2.0),
+        Transform {
+            translation: Vec3::new(5.0, 0.0, 0.0),
+            rotation: Quat::from_rotation_z(-0.523599),
+            ..default()
+        },
+        GlobalTransform::default(),
+        RigidBody::Static,
+    ));
+
+    app.world.spawn(VehicleBundle::default());
+
+    for _ in 0..120 {
+        app.update();
+    }
+
+    let tf = app
+        .world
+        .query::<&Transform, With<Vehicle>>()
+        .single(&app.world);
+    assert!(tf.translation.z > 0.0);
+}


### PR DESCRIPTION
## Summary
- integrate VehiclePlugin in main and replace PlayerControlPlugin
- spawn a vehicle as the player entity in the world setup
- spawn basic wheels for the vehicle

## Testing
- No tests run as per AGENTS.md

------
https://chatgpt.com/codex/tasks/task_e_68672dc48de483219eb0546ff3b792f0