### PR TITLE
Add basic vehicle plugin with suspension

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -16,7 +16,7 @@ impl Plugin for CameraPlugin {
 
 fn setup_camera(
     mut commands: Commands,
-    player_q: Query<&Transform, With<Player>>,
+    player_q: Query<&GlobalTransform, With<Player>>,
     cam_q: Query<(), With<FollowCamera>>,
     params: Res<GameParams>,
 ) {
@@ -25,6 +25,7 @@ fn setup_camera(
     }
 
     if let Ok(player_tf) = player_q.single() {
+        let player_tf = player_tf.compute_transform();
         let forward = player_tf.rotation * Vec3::Z;
         let cam_pos =
             player_tf.translation - forward * params.cam_distance + Vec3::Y * params.cam_height;
@@ -40,11 +41,13 @@ fn setup_camera(
 fn follow_camera_system(
     params: Res<GameParams>,
     mut cam_q: Query<&mut Transform, With<FollowCamera>>,
-    target_q: Query<&Transform, (With<Player>, Without<FollowCamera>)>,
+    target_q: Query<&GlobalTransform, (With<Player>, Without<FollowCamera>)>,
 ) {
     let Ok(target_tf) = target_q.single() else {
         return;
     };
+
+    let target_tf = target_tf.compute_transform();
 
     for mut cam_tf in &mut cam_q {
         let forward = target_tf.rotation * Vec3::Z;

--- a/src/input.rs
+++ b/src/input.rs
@@ -26,6 +26,8 @@ pub struct Player {
     pub grounded: bool,
     pub fire_timer: f32,
     pub weapon_energy: f32,
+    /// Vehicle this player is riding in.
+    pub vehicle: Option<Entity>,
 }
 
 pub struct PlayerControlPlugin;
@@ -51,6 +53,9 @@ fn player_input_system(
 ) {
     let dt = time.delta_secs();
     for mut plyr in &mut q {
+        if plyr.vehicle.is_some() {
+            continue;
+        }
         update_speed(&keys, &params, &mut plyr, dt);
         update_yaw(&keys, &params, &mut plyr, dt);
     }
@@ -64,6 +69,9 @@ fn player_move_system(
 ) {
     let dt = time.delta_secs() / SUBSTEPS as f32;
     for (entity, mut tf, mut plyr) in &mut q {
+        if plyr.vehicle.is_some() {
+            continue;
+        }
         let col = Collider::cuboid(
             plyr.half_extents.x,
             plyr.half_extents.y,
@@ -81,6 +89,9 @@ fn player_orientation_system(
     mut q: Query<(Entity, &mut Transform, &mut Player)>,
 ) {
     for (entity, mut tf, mut plyr) in &mut q {
+        if plyr.vehicle.is_some() {
+            continue;
+        }
         apply_ground_snap(&spatial, entity, &mut tf, &mut plyr);
         orient_to_ground(&spatial, entity, &mut tf, &plyr);
     }
@@ -263,6 +274,9 @@ fn orient_to_ground(spatial: &SpatialQuery, entity: Entity, tf: &mut Transform, 
 
 fn fall_reset_system(mut q: Query<(&mut Transform, &mut Player)>) {
     for (mut tf, mut plyr) in &mut q {
+        if plyr.vehicle.is_some() {
+            continue;
+        }
         if tf.translation.y < FALL_RESET_Y {
             info!("respawn");
             tf.translation = RESPAWN_POS;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod lap_timer;
 pub mod socket_client;
 pub mod chat;
 pub mod hp_text;
+pub mod vehicle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use game_demo::goals::GoalsPlugin;
 use game_demo::lap_timer::LapTimerPlugin;
 use game_demo::socket_client::SocketClientPlugin;
 use game_demo::chat::ChatPlugin;
+use game_demo::vehicle::VehiclePlugin;
 
 fn main() {
     App::new()
@@ -27,6 +28,7 @@ fn main() {
         .insert_resource(GameParams::default())
         .add_plugins((
             WorldPlugin,
+            VehiclePlugin,
             TargetsPlugin,
             GoalsPlugin,
             SkyDomePlugin,

--- a/src/vehicle/chassis.rs
+++ b/src/vehicle/chassis.rs
@@ -19,11 +19,17 @@ impl Plugin for ChassisPlugin {
 /// Spawn the vehicle chassis body and attach it to the player.
 pub fn spawn_chassis(
     mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
     mut players: Query<(Entity, &Transform, &mut Player)>,
 ) {
     let Ok((p_ent, p_tf, mut player)) = players.single_mut() else { return; };
+    let mesh = meshes.add(Cuboid::new(1.0, 0.5, 2.0));
+    let material = materials.add(Color::srgb(0.3, 0.3, 0.35));
     let chassis = commands
         .spawn((
+            Mesh3d(mesh),
+            MeshMaterial3d(material),
             RigidBody::Dynamic,
             Collider::cuboid(1.0, 0.5, 2.0),
             Mass(160.0),

--- a/src/vehicle/chassis.rs
+++ b/src/vehicle/chassis.rs
@@ -34,7 +34,7 @@ pub fn spawn_chassis(
             Chassis,
         ))
         .id();
-    commands.entity(chassis).push_children(&[p_ent]);
+    commands.entity(chassis).add_child(p_ent);
     commands.entity(p_ent).insert(Transform::from_xyz(0.0, 1.0, 0.0));
     player.vehicle = Some(chassis);
 }

--- a/src/vehicle/chassis.rs
+++ b/src/vehicle/chassis.rs
@@ -41,7 +41,11 @@ pub fn spawn_chassis(
         ))
         .id();
     commands.entity(chassis).add_child(p_ent);
-    commands.entity(p_ent).insert(Transform::from_xyz(0.0, 1.0, 0.0));
+    commands
+        .entity(p_ent)
+        .insert(Transform::from_xyz(0.0, 1.0, 0.0))
+        .remove::<RigidBody>()
+        .remove::<Collider>();
     player.vehicle = Some(chassis);
 }
 

--- a/src/vehicle/chassis.rs
+++ b/src/vehicle/chassis.rs
@@ -1,0 +1,16 @@
+use avian3d::prelude::*;
+use bevy::prelude::*;
+
+/// Marker for the vehicle chassis.
+#[derive(Component)]
+pub struct Chassis;
+
+pub struct ChassisPlugin;
+
+impl Plugin for ChassisPlugin { fn build(&self, app: &mut App) { app.add_systems(Startup, spawn_chassis); } }
+
+pub fn spawn_chassis(mut commands: Commands) {
+    commands.spawn((RigidBody::Dynamic, Collider::cuboid(1.0,0.5,2.0), Mass(160.0),
+        CenterOfMass::new(0.0,-0.3,0.0), AngularInertia::new(Vec3::splat(50.0)),
+        Transform::from_xyz(0.0,1.5,0.0), ExternalForce::default().with_persistence(false), Chassis));
+}

--- a/src/vehicle/chassis.rs
+++ b/src/vehicle/chassis.rs
@@ -11,7 +11,7 @@ pub struct ChassisPlugin;
 
 impl Plugin for ChassisPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (spawn_chassis, drive_chassis_system));
+        app.add_systems(Update, spawn_chassis);
     }
 }
 
@@ -53,13 +53,4 @@ pub fn spawn_chassis(
     player.vehicle = Some(chassis);
 }
 
-fn drive_chassis_system(
-    cmd: Res<DriveCmd>,
-    mut q: Query<(&Transform, &mut ExternalForce), With<Chassis>>,
-) {
-    let Ok((tf, mut force)) = q.single_mut() else {
-        return;
-    };
-    let forward = tf.rotation * Vec3::Z;
-    force.apply_force(forward * cmd.throttle * 2_000.0);
-}
+// Driving forces are applied directly to the wheels now.

--- a/src/vehicle/chassis.rs
+++ b/src/vehicle/chassis.rs
@@ -1,5 +1,7 @@
 use avian3d::prelude::*;
 use bevy::prelude::*;
+use crate::input::Player;
+use super::controls::DriveCmd;
 
 /// Marker for the vehicle chassis.
 #[derive(Component)]
@@ -9,20 +11,39 @@ pub struct ChassisPlugin;
 
 impl Plugin for ChassisPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_chassis);
+        app.add_systems(Startup, spawn_chassis)
+            .add_systems(Update, drive_chassis_system);
     }
 }
 
-/// Spawn the vehicle chassis body.
-pub fn spawn_chassis(mut commands: Commands) {
-    commands.spawn((
-        RigidBody::Dynamic,
-        Collider::cuboid(1.0, 0.5, 2.0),
-        Mass(160.0),
-        CenterOfMass::new(0.0, -0.3, 0.0),
-        AngularInertia::new(Vec3::splat(50.0)),
-        Transform::from_xyz(0.0, 1.5, 0.0),
-        ExternalForce::default().with_persistence(false),
-        Chassis,
-    ));
+/// Spawn the vehicle chassis body and attach it to the player.
+pub fn spawn_chassis(
+    mut commands: Commands,
+    mut players: Query<(Entity, &Transform, &mut Player)>,
+) {
+    let Ok((p_ent, p_tf, mut player)) = players.single_mut() else { return; };
+    let chassis = commands
+        .spawn((
+            RigidBody::Dynamic,
+            Collider::cuboid(1.0, 0.5, 2.0),
+            Mass(160.0),
+            CenterOfMass::new(0.0, -0.3, 0.0),
+            AngularInertia::new(Vec3::splat(50.0)),
+            Transform::from_translation(p_tf.translation),
+            ExternalForce::default().with_persistence(false),
+            Chassis,
+        ))
+        .id();
+    commands.entity(chassis).push_children(&[p_ent]);
+    commands.entity(p_ent).insert(Transform::from_xyz(0.0, 1.0, 0.0));
+    player.vehicle = Some(chassis);
+}
+
+fn drive_chassis_system(
+    cmd: Res<DriveCmd>,
+    mut q: Query<(&Transform, &mut ExternalForce), With<Chassis>>,
+) {
+    let Ok((tf, mut force)) = q.single_mut() else { return; };
+    let forward = tf.rotation * Vec3::Z;
+    force.apply_force(forward * cmd.throttle * 2_000.0);
 }

--- a/src/vehicle/chassis.rs
+++ b/src/vehicle/chassis.rs
@@ -7,10 +7,22 @@ pub struct Chassis;
 
 pub struct ChassisPlugin;
 
-impl Plugin for ChassisPlugin { fn build(&self, app: &mut App) { app.add_systems(Startup, spawn_chassis); } }
+impl Plugin for ChassisPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, spawn_chassis);
+    }
+}
 
+/// Spawn the vehicle chassis body.
 pub fn spawn_chassis(mut commands: Commands) {
-    commands.spawn((RigidBody::Dynamic, Collider::cuboid(1.0,0.5,2.0), Mass(160.0),
-        CenterOfMass::new(0.0,-0.3,0.0), AngularInertia::new(Vec3::splat(50.0)),
-        Transform::from_xyz(0.0,1.5,0.0), ExternalForce::default().with_persistence(false), Chassis));
+    commands.spawn((
+        RigidBody::Dynamic,
+        Collider::cuboid(1.0, 0.5, 2.0),
+        Mass(160.0),
+        CenterOfMass::new(0.0, -0.3, 0.0),
+        AngularInertia::new(Vec3::splat(50.0)),
+        Transform::from_xyz(0.0, 1.5, 0.0),
+        ExternalForce::default().with_persistence(false),
+        Chassis,
+    ));
 }

--- a/src/vehicle/controls.rs
+++ b/src/vehicle/controls.rs
@@ -6,14 +6,20 @@ pub enum DriveMode { Fwd, Rwd, Awd }
 
 /// Commanded throttle, steering and handbrake state.
 #[derive(Resource, Default)]
-pub struct DriveCmd { pub throttle: f32, pub steer: f32, pub handbrake: bool }
+pub struct DriveCmd {
+    pub throttle: f32,
+    pub steer: f32,
+    pub handbrake: bool,
+}
 
 /// Handles keyboard input and updates [`DriveCmd`].
 pub struct VehicleControlsPlugin;
 
 impl Plugin for VehicleControlsPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(DriveCmd::default()).insert_resource(DriveMode::Awd).add_systems(Update, read_input);
+        app.insert_resource(DriveCmd::default())
+            .insert_resource(DriveMode::Awd)
+            .add_systems(Update, read_input);
     }
 }
 

--- a/src/vehicle/controls.rs
+++ b/src/vehicle/controls.rs
@@ -1,0 +1,26 @@
+use bevy::prelude::*;
+
+/// Selected drive train mode.
+#[derive(Resource, Clone, Copy, PartialEq, Eq)]
+pub enum DriveMode { Fwd, Rwd, Awd }
+
+/// Commanded throttle, steering and handbrake state.
+#[derive(Resource, Default)]
+pub struct DriveCmd { pub throttle: f32, pub steer: f32, pub handbrake: bool }
+
+/// Handles keyboard input and updates [`DriveCmd`].
+pub struct VehicleControlsPlugin;
+
+impl Plugin for VehicleControlsPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(DriveCmd::default()).insert_resource(DriveMode::Awd).add_systems(Update, read_input);
+    }
+}
+
+fn read_input(keys: Res<ButtonInput<KeyCode>>, mut cmd: ResMut<DriveCmd>) {
+    let t = keys.pressed(KeyCode::ArrowUp) as i8 - keys.pressed(KeyCode::ArrowDown) as i8;
+    let s = keys.pressed(KeyCode::ArrowRight) as i8 - keys.pressed(KeyCode::ArrowLeft) as i8;
+    cmd.throttle = t as f32;
+    cmd.steer = s as f32;
+    cmd.handbrake = keys.pressed(KeyCode::Space);
+}

--- a/src/vehicle/mod.rs
+++ b/src/vehicle/mod.rs
@@ -1,0 +1,7 @@
+pub mod vehicle_plugin;
+pub mod chassis;
+pub mod suspension;
+pub mod wheel;
+pub mod controls;
+
+pub use vehicle_plugin::VehiclePlugin;

--- a/src/vehicle/suspension.rs
+++ b/src/vehicle/suspension.rs
@@ -92,7 +92,7 @@ pub fn suspension_system(
     let Ok((ct, mut cf, cv)) = ch_q.single_mut() else {
         return;
     };
-    let axis = ct.rotation * Vec3::Y;
+    let axis = Vec3::Y;
     for (hub, tf, mut ext_f, vel) in &mut hubs {
         let rest = ct.translation + hub.offset;
         let d = (tf.translation - rest).dot(axis);

--- a/src/vehicle/suspension.rs
+++ b/src/vehicle/suspension.rs
@@ -22,10 +22,12 @@ impl Default for SuspensionParams {
     }
 }
 
+/// Connection point between a wheel and the chassis.
 #[derive(Component)]
-pub struct SuspensionArm {
+pub struct WheelHub {
     pub chassis: Entity,
     pub offset: Vec3,
+    pub front: bool,
 }
 
 pub struct SuspensionPlugin;
@@ -38,60 +40,61 @@ impl Plugin for SuspensionPlugin {
 }
 
 /// Spawn a suspension arm entity attached to the given chassis.
-pub fn spawn_arm(
+pub fn spawn_hub(
     commands: &mut Commands,
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<StandardMaterial>,
     chassis: Entity,
     chassis_tf: &Transform,
     offset: Vec3,
+    front: bool,
     params: &SuspensionParams,
 ) -> Entity {
-    let mesh = meshes.add(Cylinder::new(0.1, params.max_travel * 2.0));
-    let material = materials.add(Color::srgb(0.2, 0.2, 0.2));
-    let arm_pos = chassis_tf.translation + offset;
-    let arm = commands
+    const SPREAD: f32 = 0.5;
+    let hub_pos = chassis_tf.translation + offset;
+    let hub = commands
         .spawn((
-            Mesh3d(mesh),
-            MeshMaterial3d(material),
+            Mesh3d(meshes.add(Cylinder::new(0.05, SPREAD))),
+            MeshMaterial3d(materials.add(Color::srgb(0.2, 0.2, 0.2))),
             RigidBody::Dynamic,
             Mass(0.0),
-            Transform::from_translation(arm_pos),
+            Transform::from_translation(hub_pos),
             ExternalForce::default().with_persistence(false),
-            SuspensionArm { chassis, offset },
+            WheelHub {
+                chassis,
+                offset,
+                front,
+            },
         ))
         .id();
-    commands.spawn(
-        PrismaticJoint::new(chassis, arm)
-            .with_local_anchor_1(offset)
-            .with_local_anchor_2(Vec3::ZERO)
-            .with_free_axis(Vec3::Y)
-            .with_limits(-params.max_travel, 0.0)
-            .with_compliance(1.0 / params.spring_k)
-            .with_linear_velocity_damping(params.damping_c / params.spring_k),
-    );
-    arm
+
+    for side in [-0.5, 0.5] {
+        let anchor = Vec3::new(side * SPREAD, 0.0, 0.0);
+        commands.spawn(
+            PrismaticJoint::new(chassis, hub)
+                .with_local_anchor_1(offset + anchor)
+                .with_local_anchor_2(anchor)
+                .with_free_axis(Vec3::Y)
+                .with_limits(-params.max_travel, 0.0)
+                .with_compliance(1.0 / params.spring_k)
+                .with_linear_velocity_damping(params.damping_c / params.spring_k),
+        );
+    }
+
+    hub
 }
 
 pub fn suspension_system(
     params: Res<SuspensionParams>,
-    mut arms: Query<
-        (
-            &SuspensionArm,
-            &Transform,
-            &mut ExternalForce,
-            &LinearVelocity,
-        ),
-        Without<Chassis>,
-    >,
+    mut hubs: Query<(&WheelHub, &Transform, &mut ExternalForce, &LinearVelocity), Without<Chassis>>,
     mut ch_q: Query<(&Transform, &mut ExternalForce, &LinearVelocity), With<Chassis>>,
 ) {
     let Ok((ct, mut cf, cv)) = ch_q.single_mut() else {
         return;
     };
     let axis = ct.rotation * Vec3::Y;
-    for (arm, tf, mut ext_f, vel) in &mut arms {
-        let rest = ct.translation + arm.offset;
+    for (hub, tf, mut ext_f, vel) in &mut hubs {
+        let rest = ct.translation + hub.offset;
         let d = (tf.translation - rest).dot(axis);
         let v = (vel.0 - cv.0).dot(axis);
         let spring = params.spring_k * -d - params.damping_c * v;

--- a/src/vehicle/suspension.rs
+++ b/src/vehicle/suspension.rs
@@ -1,0 +1,31 @@
+use avian3d::prelude::*;
+use bevy::prelude::*;
+
+use super::chassis::Chassis;
+
+/// Suspension tuning parameters.
+#[derive(Resource)]
+pub struct SuspensionParams { pub spring_k: f32, pub damping_c: f32, pub max_travel: f32 }
+
+impl Default for SuspensionParams { fn default() -> Self { Self{ spring_k:40000.0, damping_c:4000.0, max_travel:0.75 } } }
+
+#[derive(Component)]
+pub struct SuspensionArm { pub chassis: Entity }
+
+pub struct SuspensionPlugin;
+
+impl Plugin for SuspensionPlugin { fn build(&self, app: &mut App) { app.insert_resource(SuspensionParams::default()).add_systems(Update, suspension_system); } }
+
+pub fn spawn_arm(commands: &mut Commands, chassis: Entity, offset: Vec3, params: &SuspensionParams) -> Entity {
+    let arm = commands.spawn((RigidBody::Dynamic, Mass(0.0), Transform::from_translation(offset), ExternalForce::default().with_persistence(false), SuspensionArm{chassis})).id();
+    commands.spawn(PrismaticJoint::new(chassis,arm).with_local_anchor_1(offset).with_limits(-params.max_travel,0.0).with_compliance(1.0/params.spring_k).with_linear_velocity_damping(params.damping_c/params.spring_k));
+    arm
+}
+
+pub fn suspension_system(params: Res<SuspensionParams>, mut arms: Query<(&Transform,&mut ExternalForce,&LinearVelocity),With<SuspensionArm>>, mut ch_q: Query<(&Transform,&mut ExternalForce,&LinearVelocity),With<Chassis>>) {
+    let (ct,mut cf,cv)=ch_q.single_mut(); let axis=ct.rotation*Vec3::Y;
+    for (tf,mut f,vel) in &mut arms {
+        let (d,v)=((tf.translation-ct.translation).dot(axis),(vel.0-cv.0).dot(axis));
+        let f=params.spring_k*-d-params.damping_c*v; f.apply_force(axis*f); cf.apply_force(-axis*f);
+    }
+}

--- a/src/vehicle/suspension.rs
+++ b/src/vehicle/suspension.rs
@@ -63,10 +63,15 @@ pub fn spawn_arm(
 
 pub fn suspension_system(
     params: Res<SuspensionParams>,
-    mut arms: Query<(&Transform, &mut ExternalForce, &LinearVelocity), With<SuspensionArm>>,
+    mut arms: Query<
+        (&Transform, &mut ExternalForce, &LinearVelocity),
+        (With<SuspensionArm>, Without<Chassis>),
+    >,
     mut ch_q: Query<(&Transform, &mut ExternalForce, &LinearVelocity), With<Chassis>>,
 ) {
-    let Ok((ct, mut cf, cv)) = ch_q.single_mut() else { return; };
+    let Ok((ct, mut cf, cv)) = ch_q.single_mut() else {
+        return;
+    };
     let axis = ct.rotation * Vec3::Y;
     for (tf, mut ext_f, vel) in &mut arms {
         let d = (tf.translation - ct.translation).dot(axis);

--- a/src/vehicle/suspension.rs
+++ b/src/vehicle/suspension.rs
@@ -1,5 +1,6 @@
 use avian3d::prelude::*;
 use bevy::prelude::*;
+use bevy::math::primitives::Cylinder;
 
 use super::chassis::Chassis;
 
@@ -38,12 +39,18 @@ impl Plugin for SuspensionPlugin {
 /// Spawn a suspension arm entity attached to the given chassis.
 pub fn spawn_arm(
     commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    materials: &mut Assets<StandardMaterial>,
     chassis: Entity,
     offset: Vec3,
     params: &SuspensionParams,
 ) -> Entity {
+    let mesh = meshes.add(Cylinder::new(0.1, params.max_travel * 2.0));
+    let material = materials.add(Color::srgb(0.2, 0.2, 0.2));
     let arm = commands
         .spawn((
+            Mesh3d(mesh),
+            MeshMaterial3d(material),
             RigidBody::Dynamic,
             Mass(0.0),
             Transform::from_translation(offset),

--- a/src/vehicle/suspension.rs
+++ b/src/vehicle/suspension.rs
@@ -5,27 +5,74 @@ use super::chassis::Chassis;
 
 /// Suspension tuning parameters.
 #[derive(Resource)]
-pub struct SuspensionParams { pub spring_k: f32, pub damping_c: f32, pub max_travel: f32 }
+pub struct SuspensionParams {
+    pub spring_k: f32,
+    pub damping_c: f32,
+    pub max_travel: f32,
+}
 
-impl Default for SuspensionParams { fn default() -> Self { Self{ spring_k:40000.0, damping_c:4000.0, max_travel:0.75 } } }
+impl Default for SuspensionParams {
+    fn default() -> Self {
+        Self {
+            spring_k: 40_000.0,
+            damping_c: 4_000.0,
+            max_travel: 0.75,
+        }
+    }
+}
 
 #[derive(Component)]
-pub struct SuspensionArm { pub chassis: Entity }
+pub struct SuspensionArm {
+    pub chassis: Entity,
+}
 
 pub struct SuspensionPlugin;
 
-impl Plugin for SuspensionPlugin { fn build(&self, app: &mut App) { app.insert_resource(SuspensionParams::default()).add_systems(Update, suspension_system); } }
+impl Plugin for SuspensionPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(SuspensionParams::default())
+            .add_systems(Update, suspension_system);
+    }
+}
 
-pub fn spawn_arm(commands: &mut Commands, chassis: Entity, offset: Vec3, params: &SuspensionParams) -> Entity {
-    let arm = commands.spawn((RigidBody::Dynamic, Mass(0.0), Transform::from_translation(offset), ExternalForce::default().with_persistence(false), SuspensionArm{chassis})).id();
-    commands.spawn(PrismaticJoint::new(chassis,arm).with_local_anchor_1(offset).with_limits(-params.max_travel,0.0).with_compliance(1.0/params.spring_k).with_linear_velocity_damping(params.damping_c/params.spring_k));
+/// Spawn a suspension arm entity attached to the given chassis.
+pub fn spawn_arm(
+    commands: &mut Commands,
+    chassis: Entity,
+    offset: Vec3,
+    params: &SuspensionParams,
+) -> Entity {
+    let arm = commands
+        .spawn((
+            RigidBody::Dynamic,
+            Mass(0.0),
+            Transform::from_translation(offset),
+            ExternalForce::default().with_persistence(false),
+            SuspensionArm { chassis },
+        ))
+        .id();
+    commands.spawn(
+        PrismaticJoint::new(chassis, arm)
+            .with_local_anchor_1(offset)
+            .with_limits(-params.max_travel, 0.0)
+            .with_compliance(1.0 / params.spring_k)
+            .with_linear_velocity_damping(params.damping_c / params.spring_k),
+    );
     arm
 }
 
-pub fn suspension_system(params: Res<SuspensionParams>, mut arms: Query<(&Transform,&mut ExternalForce,&LinearVelocity),With<SuspensionArm>>, mut ch_q: Query<(&Transform,&mut ExternalForce,&LinearVelocity),With<Chassis>>) {
-    let (ct,mut cf,cv)=ch_q.single_mut(); let axis=ct.rotation*Vec3::Y;
-    for (tf,mut f,vel) in &mut arms {
-        let (d,v)=((tf.translation-ct.translation).dot(axis),(vel.0-cv.0).dot(axis));
-        let f=params.spring_k*-d-params.damping_c*v; f.apply_force(axis*f); cf.apply_force(-axis*f);
+pub fn suspension_system(
+    params: Res<SuspensionParams>,
+    mut arms: Query<(&Transform, &mut ExternalForce, &LinearVelocity), With<SuspensionArm>>,
+    mut ch_q: Query<(&Transform, &mut ExternalForce, &LinearVelocity), With<Chassis>>,
+) {
+    let Ok((ct, mut cf, cv)) = ch_q.single_mut() else { return; };
+    let axis = ct.rotation * Vec3::Y;
+    for (tf, mut ext_f, vel) in &mut arms {
+        let d = (tf.translation - ct.translation).dot(axis);
+        let v = (vel.0 - cv.0).dot(axis);
+        let spring = params.spring_k * -d - params.damping_c * v;
+        ext_f.apply_force(axis * spring);
+        cf.apply_force(-axis * spring);
     }
 }

--- a/src/vehicle/suspension.rs
+++ b/src/vehicle/suspension.rs
@@ -1,6 +1,6 @@
 use avian3d::prelude::*;
-use bevy::prelude::*;
 use bevy::math::primitives::Cylinder;
+use bevy::prelude::*;
 
 use super::chassis::Chassis;
 
@@ -25,6 +25,7 @@ impl Default for SuspensionParams {
 #[derive(Component)]
 pub struct SuspensionArm {
     pub chassis: Entity,
+    pub offset: Vec3,
 }
 
 pub struct SuspensionPlugin;
@@ -42,25 +43,29 @@ pub fn spawn_arm(
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<StandardMaterial>,
     chassis: Entity,
+    chassis_tf: &Transform,
     offset: Vec3,
     params: &SuspensionParams,
 ) -> Entity {
     let mesh = meshes.add(Cylinder::new(0.1, params.max_travel * 2.0));
     let material = materials.add(Color::srgb(0.2, 0.2, 0.2));
+    let arm_pos = chassis_tf.translation + offset;
     let arm = commands
         .spawn((
             Mesh3d(mesh),
             MeshMaterial3d(material),
             RigidBody::Dynamic,
             Mass(0.0),
-            Transform::from_translation(offset),
+            Transform::from_translation(arm_pos),
             ExternalForce::default().with_persistence(false),
-            SuspensionArm { chassis },
+            SuspensionArm { chassis, offset },
         ))
         .id();
     commands.spawn(
         PrismaticJoint::new(chassis, arm)
             .with_local_anchor_1(offset)
+            .with_local_anchor_2(Vec3::ZERO)
+            .with_free_axis(Vec3::Y)
             .with_limits(-params.max_travel, 0.0)
             .with_compliance(1.0 / params.spring_k)
             .with_linear_velocity_damping(params.damping_c / params.spring_k),
@@ -71,8 +76,13 @@ pub fn spawn_arm(
 pub fn suspension_system(
     params: Res<SuspensionParams>,
     mut arms: Query<
-        (&Transform, &mut ExternalForce, &LinearVelocity),
-        (With<SuspensionArm>, Without<Chassis>),
+        (
+            &SuspensionArm,
+            &Transform,
+            &mut ExternalForce,
+            &LinearVelocity,
+        ),
+        Without<Chassis>,
     >,
     mut ch_q: Query<(&Transform, &mut ExternalForce, &LinearVelocity), With<Chassis>>,
 ) {
@@ -80,8 +90,9 @@ pub fn suspension_system(
         return;
     };
     let axis = ct.rotation * Vec3::Y;
-    for (tf, mut ext_f, vel) in &mut arms {
-        let d = (tf.translation - ct.translation).dot(axis);
+    for (arm, tf, mut ext_f, vel) in &mut arms {
+        let rest = ct.translation + arm.offset;
+        let d = (tf.translation - rest).dot(axis);
         let v = (vel.0 - cv.0).dot(axis);
         let spring = params.spring_k * -d - params.damping_c * v;
         ext_f.apply_force(axis * spring);

--- a/src/vehicle/vehicle_plugin.rs
+++ b/src/vehicle/vehicle_plugin.rs
@@ -1,12 +1,22 @@
 use bevy::prelude::*;
 
-use super::{chassis::ChassisPlugin, controls::VehicleControlsPlugin, suspension::SuspensionPlugin, wheel::WheelPlugin};
+use super::{
+    chassis::ChassisPlugin,
+    controls::VehicleControlsPlugin,
+    suspension::SuspensionPlugin,
+    wheel::WheelPlugin,
+};
 
 /// Plugin grouping all vehicle related plugins.
 pub struct VehiclePlugin;
 
 impl Plugin for VehiclePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((VehicleControlsPlugin, ChassisPlugin, SuspensionPlugin, WheelPlugin));
+        app.add_plugins((
+            VehicleControlsPlugin,
+            ChassisPlugin,
+            SuspensionPlugin,
+            WheelPlugin,
+        ));
     }
 }

--- a/src/vehicle/vehicle_plugin.rs
+++ b/src/vehicle/vehicle_plugin.rs
@@ -1,0 +1,12 @@
+use bevy::prelude::*;
+
+use super::{chassis::ChassisPlugin, controls::VehicleControlsPlugin, suspension::SuspensionPlugin, wheel::WheelPlugin};
+
+/// Plugin grouping all vehicle related plugins.
+pub struct VehiclePlugin;
+
+impl Plugin for VehiclePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins((VehicleControlsPlugin, ChassisPlugin, SuspensionPlugin, WheelPlugin));
+    }
+}

--- a/src/vehicle/wheel.rs
+++ b/src/vehicle/wheel.rs
@@ -9,17 +9,45 @@ pub struct Wheel { pub front: bool }
 
 pub struct WheelPlugin;
 
-impl Plugin for WheelPlugin { fn build(&self, app: &mut App) { app.add_systems(Startup, spawn_vehicle_wheels); } }
-
-fn spawn_vehicle_wheels(mut commands: Commands, chassis_q: Query<Entity, With<Chassis>>, params: Res<super::suspension::SuspensionParams>) {
-    let Ok(chassis) = chassis_q.get_single() else { return; };
-    let offs = [Vec3::new(-1.0,-0.75, 1.5), Vec3::new(1.0,-0.75,1.5), Vec3::new(-1.0,-0.75,-1.5), Vec3::new(1.0,-0.75,-1.5)];
-    for (i,o) in offs.into_iter().enumerate() { let arm = super::suspension::spawn_arm(&mut commands,chassis,o,&params); spawn_wheel(&mut commands,arm,i<2); }
+impl Plugin for WheelPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, spawn_vehicle_wheels);
+    }
 }
 
+/// Spawn all four wheels for the vehicle.
+fn spawn_vehicle_wheels(
+    mut commands: Commands,
+    chassis_q: Query<Entity, With<Chassis>>,
+    params: Res<super::suspension::SuspensionParams>,
+) {
+    let Ok(chassis) = chassis_q.single() else { return; };
+    let offs = [
+        Vec3::new(-1.0, -0.75, 1.5),
+        Vec3::new(1.0, -0.75, 1.5),
+        Vec3::new(-1.0, -0.75, -1.5),
+        Vec3::new(1.0, -0.75, -1.5),
+    ];
+    for (i, o) in offs.into_iter().enumerate() {
+        let arm = super::suspension::spawn_arm(&mut commands, chassis, o, &params);
+        spawn_wheel(&mut commands, arm, i < 2);
+    }
+}
+
+/// Spawn a single wheel body under the given suspension arm.
 pub fn spawn_wheel(commands: &mut Commands, arm: Entity, front: bool) -> Entity {
     let rot = Quat::from_rotation_z(std::f32::consts::FRAC_PI_2);
-    let wheel = commands.spawn((RigidBody::Dynamic, Collider::cylinder(0.75,0.15), Mass(10.0), Transform::from_rotation(rot), ExternalForce::default().with_persistence(false), ExternalTorque::default().with_persistence(false), Wheel{front})).id();
-    commands.spawn(RevoluteJoint::new(arm,wheel).with_aligned_axis(Vec3::X));
+    let wheel = commands
+        .spawn((
+            RigidBody::Dynamic,
+            Collider::cylinder(0.75, 0.15),
+            Mass(10.0),
+            Transform::from_rotation(rot),
+            ExternalForce::default().with_persistence(false),
+            ExternalTorque::default().with_persistence(false),
+            Wheel { front },
+        ))
+        .id();
+    commands.spawn(RevoluteJoint::new(arm, wheel).with_aligned_axis(Vec3::X));
     wheel
 }

--- a/src/vehicle/wheel.rs
+++ b/src/vehicle/wheel.rs
@@ -1,0 +1,25 @@
+use avian3d::prelude::*;
+use bevy::prelude::*;
+
+use super::chassis::Chassis;
+
+/// A wheel entity.
+#[derive(Component)]
+pub struct Wheel { pub front: bool }
+
+pub struct WheelPlugin;
+
+impl Plugin for WheelPlugin { fn build(&self, app: &mut App) { app.add_systems(Startup, spawn_vehicle_wheels); } }
+
+fn spawn_vehicle_wheels(mut commands: Commands, chassis_q: Query<Entity, With<Chassis>>, params: Res<super::suspension::SuspensionParams>) {
+    let Ok(chassis) = chassis_q.get_single() else { return; };
+    let offs = [Vec3::new(-1.0,-0.75, 1.5), Vec3::new(1.0,-0.75,1.5), Vec3::new(-1.0,-0.75,-1.5), Vec3::new(1.0,-0.75,-1.5)];
+    for (i,o) in offs.into_iter().enumerate() { let arm = super::suspension::spawn_arm(&mut commands,chassis,o,&params); spawn_wheel(&mut commands,arm,i<2); }
+}
+
+pub fn spawn_wheel(commands: &mut Commands, arm: Entity, front: bool) -> Entity {
+    let rot = Quat::from_rotation_z(std::f32::consts::FRAC_PI_2);
+    let wheel = commands.spawn((RigidBody::Dynamic, Collider::cylinder(0.75,0.15), Mass(10.0), Transform::from_rotation(rot), ExternalForce::default().with_persistence(false), ExternalTorque::default().with_persistence(false), Wheel{front})).id();
+    commands.spawn(RevoluteJoint::new(arm,wheel).with_aligned_axis(Vec3::X));
+    wheel
+}

--- a/src/vehicle/wheel.rs
+++ b/src/vehicle/wheel.rs
@@ -1,5 +1,6 @@
 use avian3d::prelude::*;
 use bevy::prelude::*;
+use bevy::math::primitives::Cylinder;
 
 use super::chassis::Chassis;
 
@@ -18,6 +19,8 @@ impl Plugin for WheelPlugin {
 /// Spawn all four wheels for the vehicle.
 fn spawn_vehicle_wheels(
     mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
     chassis_q: Query<Entity, With<Chassis>>,
     params: Res<super::suspension::SuspensionParams>,
 ) {
@@ -29,16 +32,39 @@ fn spawn_vehicle_wheels(
         Vec3::new(1.0, -0.75, -1.5),
     ];
     for (i, o) in offs.into_iter().enumerate() {
-        let arm = super::suspension::spawn_arm(&mut commands, chassis, o, &params);
-        spawn_wheel(&mut commands, arm, i < 2);
+        let arm = super::suspension::spawn_arm(
+            &mut commands,
+            meshes.as_mut(),
+            materials.as_mut(),
+            chassis,
+            o,
+            &params,
+        );
+        spawn_wheel(
+            &mut commands,
+            meshes.as_mut(),
+            materials.as_mut(),
+            arm,
+            i < 2,
+        );
     }
 }
 
 /// Spawn a single wheel body under the given suspension arm.
-pub fn spawn_wheel(commands: &mut Commands, arm: Entity, front: bool) -> Entity {
+pub fn spawn_wheel(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    materials: &mut Assets<StandardMaterial>,
+    arm: Entity,
+    front: bool,
+) -> Entity {
     let rot = Quat::from_rotation_z(std::f32::consts::FRAC_PI_2);
+    let mesh = meshes.add(Cylinder::new(0.75, 0.3));
+    let material = materials.add(Color::srgb(0.1, 0.1, 0.1));
     let wheel = commands
         .spawn((
+            Mesh3d(mesh),
+            MeshMaterial3d(material),
             RigidBody::Dynamic,
             Collider::cylinder(0.75, 0.15),
             Mass(10.0),

--- a/src/vehicle/wheel.rs
+++ b/src/vehicle/wheel.rs
@@ -1,18 +1,20 @@
 use avian3d::prelude::*;
-use bevy::prelude::*;
 use bevy::math::primitives::Cylinder;
+use bevy::prelude::*;
 
 use super::chassis::Chassis;
 
 /// A wheel entity.
 #[derive(Component)]
-pub struct Wheel { pub front: bool }
+pub struct Wheel {
+    pub front: bool,
+}
 
 pub struct WheelPlugin;
 
 impl Plugin for WheelPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_vehicle_wheels);
+        app.add_systems(Update, spawn_vehicle_wheels);
     }
 }
 
@@ -22,9 +24,15 @@ fn spawn_vehicle_wheels(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     chassis_q: Query<Entity, With<Chassis>>,
+    wheel_q: Query<(), With<Wheel>>,
     params: Res<super::suspension::SuspensionParams>,
 ) {
-    let Ok(chassis) = chassis_q.single() else { return; };
+    if !wheel_q.is_empty() {
+        return;
+    }
+    let Ok(chassis) = chassis_q.single() else {
+        return;
+    };
     let offs = [
         Vec3::new(-1.0, -0.75, 1.5),
         Vec3::new(1.0, -0.75, 1.5),

--- a/src/vehicle/wheel.rs
+++ b/src/vehicle/wheel.rs
@@ -23,14 +23,14 @@ fn spawn_vehicle_wheels(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    chassis_q: Query<Entity, With<Chassis>>,
+    chassis_q: Query<(Entity, &Transform), With<Chassis>>,
     wheel_q: Query<(), With<Wheel>>,
     params: Res<super::suspension::SuspensionParams>,
 ) {
     if !wheel_q.is_empty() {
         return;
     }
-    let Ok(chassis) = chassis_q.single() else {
+    let Ok((chassis, ch_tf)) = chassis_q.single() else {
         return;
     };
     let offs = [
@@ -45,15 +45,17 @@ fn spawn_vehicle_wheels(
             meshes.as_mut(),
             materials.as_mut(),
             chassis,
+            ch_tf,
             o,
             &params,
         );
+        let pos = ch_tf.translation + o;
         spawn_wheel(
             &mut commands,
             meshes.as_mut(),
             materials.as_mut(),
             arm,
-            o,
+            pos,
             i < 2,
         );
     }
@@ -65,7 +67,7 @@ pub fn spawn_wheel(
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<StandardMaterial>,
     arm: Entity,
-    offset: Vec3,
+    pos: Vec3,
     front: bool,
 ) -> Entity {
     let rot = Quat::from_rotation_z(std::f32::consts::FRAC_PI_2);
@@ -79,7 +81,7 @@ pub fn spawn_wheel(
             Collider::cylinder(0.75, 0.15),
             Mass(10.0),
             {
-                let mut tf = Transform::from_translation(offset);
+                let mut tf = Transform::from_translation(pos);
                 tf.rotation = rot;
                 tf
             },

--- a/src/vehicle/wheel.rs
+++ b/src/vehicle/wheel.rs
@@ -15,7 +15,7 @@ pub struct WheelPlugin;
 
 impl Plugin for WheelPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (spawn_vehicle_wheels, steer_system));
+        app.add_systems(Update, (spawn_vehicle_wheels, steer_system, drive_system));
     }
 }
 
@@ -69,6 +69,18 @@ fn steer_system(cmd: Res<super::controls::DriveCmd>, mut q: Query<(&WheelHub, &m
         if hub.front {
             tf.rotation = Quat::from_rotation_y(cmd.steer * 0.5);
         }
+    }
+}
+
+/// Apply drive torque based on user input.
+fn drive_system(
+    cmd: Res<super::controls::DriveCmd>,
+    mut q: Query<(&mut ExternalTorque, &Transform), With<Wheel>>,
+) {
+    let torque = cmd.throttle * 5_000.0;
+    for (mut t, tf) in &mut q {
+        let axis = tf.rotation * Vec3::X;
+        t.apply_torque(axis * torque);
     }
 }
 

--- a/src/vehicle/wheel.rs
+++ b/src/vehicle/wheel.rs
@@ -45,6 +45,7 @@ fn spawn_vehicle_wheels(
             meshes.as_mut(),
             materials.as_mut(),
             arm,
+            o,
             i < 2,
         );
     }
@@ -56,6 +57,7 @@ pub fn spawn_wheel(
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<StandardMaterial>,
     arm: Entity,
+    offset: Vec3,
     front: bool,
 ) -> Entity {
     let rot = Quat::from_rotation_z(std::f32::consts::FRAC_PI_2);
@@ -68,7 +70,11 @@ pub fn spawn_wheel(
             RigidBody::Dynamic,
             Collider::cylinder(0.75, 0.15),
             Mass(10.0),
-            Transform::from_rotation(rot),
+            {
+                let mut tf = Transform::from_translation(offset);
+                tf.rotation = rot;
+                tf
+            },
             ExternalForce::default().with_persistence(false),
             ExternalTorque::default().with_persistence(false),
             Wheel { front },

--- a/src/world.rs
+++ b/src/world.rs
@@ -55,5 +55,6 @@ fn setup_world(
             grounded: false,
             fire_timer: 0.0,
             weapon_energy: 1.0,
+            vehicle: None,
         });
 }


### PR DESCRIPTION
## Summary
- implement a new vehicle plugin with chassis, wheels and springy suspension
- add keyboard controls for throttle, steering and handbrake
- integrate vehicle plugin into main app

## Testing
- `cargo search avian3d | head`
- `cargo info avian3d | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686b1e2a0cd0832190e79f465aa1e781