### PR TITLE
Add vehicle physics with terrain interaction

### DIFF
--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -1,15 +1,38 @@
 use bevy::prelude::*;
-use bevy::ecs::hierarchy::ChildSpawnerCommands;
+use bevy::ecs::hierarchy::{ChildSpawnerCommands, ChildOf};
 use bevy::math::primitives::Cylinder;
-use rand::Rng;
+use avian3d::prelude::*;
 
 use crate::globals::{GameParams, Controlled, InVehicle};
 use crate::input::Player;
 
-#[derive(Component, Default)]
+const STEP_HEIGHT: f32 = 0.25;
+const MAX_SLOPE_COS: f32 = 0.707;
+const SKIN: f32 = 0.1;
+const SUBSTEPS: u32 = 4;
+const FALL_RESET_Y: f32 = -100.0;
+const RESPAWN_POS: Vec3 = Vec3::new(0.0, 1.5, 0.0);
+const RESPAWN_YAW: f32 = 0.0;
+
+#[derive(Component)]
 pub struct Vehicle {
     pub speed: f32,
+    pub vertical_vel: f32,
     pub yaw: f32,
+    pub half_extents: Vec3,
+    pub grounded: bool,
+}
+
+impl Default for Vehicle {
+    fn default() -> Self {
+        Self {
+            speed: 0.0,
+            vertical_vel: 0.0,
+            yaw: 0.0,
+            half_extents: Vec3::new(1.0, 0.5, 1.5),
+            grounded: false,
+        }
+    }
 }
 
 #[derive(Component)]
@@ -18,7 +41,6 @@ pub struct Wheel {
     pub radius: f32,
     pub rest_offset: Vec3,
     pub suspension: f32,
-    pub phase: f32,
     pub rotation: f32,
 }
 
@@ -33,7 +55,9 @@ impl Plugin for VehiclePlugin {
                     vehicle_toggle_system,
                     vehicle_input_system,
                     vehicle_move_system.after(vehicle_input_system),
-                    wheel_update_system.after(vehicle_move_system),
+                    vehicle_fall_reset_system,
+                    vehicle_orientation_system.after(vehicle_move_system),
+                    wheel_update_system.after(vehicle_orientation_system),
                     sync_player_to_vehicle_system,
                 ),
             );
@@ -55,11 +79,20 @@ fn spawn_vehicle(
     asset_server: Res<AssetServer>,
 ) {
     let scene: Handle<Scene> = asset_server.load("models/car.glb#Scene0");
+    let vehicle_defaults = Vehicle::default();
+    let collider_size = vehicle_defaults.half_extents;
     let vehicle = commands
         .spawn(SceneRoot(scene))
         .insert(Transform::from_xyz(0.0, WHEEL_RADIUS + 0.5, 0.0))
         .insert(GlobalTransform::default())
-        .insert(Vehicle::default())
+        .insert(vehicle_defaults)
+        .insert(RigidBody::Kinematic)
+        .insert(LinearVelocity::ZERO)
+        .insert(Collider::cuboid(
+            collider_size.x,
+            collider_size.y,
+            collider_size.z,
+        ))
         .id();
 
     let wheel_mesh = meshes.add(Mesh::from(Cylinder {
@@ -119,7 +152,6 @@ fn spawn_wheel(
             radius: WHEEL_RADIUS,
             rest_offset: offset,
             suspension: SUSPENSION_TRAVEL,
-            phase: rand::thread_rng().gen::<f32>() * std::f32::consts::TAU,
             rotation: 0.0,
         });
 }
@@ -152,34 +184,63 @@ fn vehicle_input_system(
 
 fn vehicle_move_system(
     time: Res<Time>,
-    mut q: Query<(&mut Transform, &Vehicle), With<Controlled>>,
+    params: Res<GameParams>,
+    spatial: SpatialQuery,
+    mut q: Query<(Entity, &mut Transform, &mut Vehicle), With<Controlled>>,
 ) {
-    let dt = time.delta_secs();
-    for (mut tf, vehicle) in &mut q {
-        let yaw_rot = Quat::from_rotation_y(vehicle.yaw);
-        tf.rotation = yaw_rot;
-        let forward = yaw_rot * Vec3::Z;
-        tf.translation += forward * vehicle.speed * dt;
+    let dt = time.delta_secs() / SUBSTEPS as f32;
+    for (entity, mut tf, mut vehicle) in &mut q {
+        let col = Collider::cuboid(
+            vehicle.half_extents.x,
+            vehicle.half_extents.y,
+            vehicle.half_extents.z,
+        );
+        for _ in 0..SUBSTEPS {
+            move_vehicle_horizontal(&spatial, &params, entity, &col, &mut tf, &mut vehicle, dt);
+            move_vehicle_vertical(&spatial, &params, entity, &col, &mut tf, &mut vehicle, dt);
+        }
+    }
+}
+
+fn vehicle_orientation_system(
+    spatial: SpatialQuery,
+    mut q: Query<(Entity, &mut Transform, &mut Vehicle), With<Controlled>>,
+) {
+    for (entity, mut tf, mut vehicle) in &mut q {
+        apply_ground_snap(&spatial, entity, &mut tf, &mut vehicle);
+        orient_to_ground(&spatial, entity, &mut tf, &vehicle);
     }
 }
 
 fn wheel_update_system(
     time: Res<Time>,
-    vehicles: Query<&Vehicle>,
+    spatial: SpatialQuery,
+    vehicles: Query<(&Transform, &Vehicle)>,
     mut wheels: Query<(&ChildOf, &mut Transform, &mut Wheel)>,
 ) {
     let dt = time.delta_secs();
-    let elapsed = time.elapsed_secs();
     for (parent, mut tf, mut wheel) in &mut wheels {
-        if let Ok(vehicle) = vehicles.get(parent.parent()) {
+        if let Ok((veh_tf, vehicle)) = vehicles.get(parent.parent()) {
             wheel.rotation += vehicle.speed * dt / wheel.radius;
             let steer = if wheel.is_front { vehicle.yaw } else { 0.0 };
-            // keep wheel upright while allowing steering and rolling
             tf.rotation =
                 Quat::from_rotation_y(steer)
                     * Quat::from_rotation_z(std::f32::consts::FRAC_PI_2)
                     * Quat::from_rotation_x(wheel.rotation);
-            let y_off = (elapsed + wheel.phase).sin() * wheel.suspension;
+
+            let world_rest = veh_tf.transform_point(wheel.rest_offset);
+            let filter = SpatialQueryFilter::default().with_excluded_entities([parent.parent()]);
+            let y_off = spatial
+                .cast_ray(
+                    world_rest + Vec3::Y * wheel.suspension,
+                    Dir3::NEG_Y,
+                    wheel.suspension + wheel.radius + SKIN,
+                    false,
+                    &filter,
+                )
+                .map(|h| wheel.suspension + wheel.radius - h.distance)
+                .unwrap_or(0.0)
+                .clamp(0.0, wheel.suspension);
             tf.translation = wheel.rest_offset + Vec3::Y * y_off;
         }
     }
@@ -239,6 +300,168 @@ fn sync_player_to_vehicle_system(
     for (mut tf, iv) in &mut players {
         if let Ok(v_tf) = vehicles.get(iv.vehicle) {
             tf.translation = v_tf.translation;
+        }
+    }
+}
+
+fn move_vehicle_horizontal(
+    spatial: &SpatialQuery,
+    params: &GameParams,
+    entity: Entity,
+    col: &Collider,
+    tf: &mut Transform,
+    veh: &mut Vehicle,
+    dt: f32,
+) {
+    let yaw_rot = Quat::from_rotation_y(veh.yaw);
+    let forward = yaw_rot * Vec3::Z;
+    let mut remaining = forward * veh.speed * dt;
+    let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
+
+    for _ in 0..3 {
+        let dist = remaining.length();
+        if dist < f32::EPSILON {
+            break;
+        }
+        let dir = Dir3::new_unchecked(remaining / dist);
+        match spatial.cast_shape(
+            col,
+            tf.translation,
+            tf.rotation,
+            dir,
+            &ShapeCastConfig {
+                compute_contact_on_penetration: true,
+                max_distance: dist + SKIN,
+                ..Default::default()
+            },
+            &filter,
+        ) {
+            Some(hit) => {
+                tf.translation += dir.as_vec3() * (hit.distance - SKIN).max(0.0);
+                if hit.normal1.y > MAX_SLOPE_COS {
+                    veh.grounded = true;
+                }
+                slide(&mut remaining, hit.normal1, veh, params);
+            }
+            None => {
+                tf.translation += remaining;
+                break;
+            }
+        }
+    }
+}
+
+fn slide(remaining: &mut Vec3, normal: Vec3, veh: &mut Vehicle, params: &GameParams) {
+    let incoming = *remaining;
+    *remaining -= remaining.dot(normal) * normal;
+
+    let mut factor = 1.0 - params.collision_damping;
+    if normal.y > 0.0 && normal.y < 1.0 {
+        let slope = 1.0 - normal.y;
+        let eased = slope.powf(params.slope_ease);
+        factor *= 1.0 - eased * params.slope_damping;
+    }
+    factor = factor.clamp(0.0, 1.0);
+    *remaining *= factor;
+    veh.speed *= factor;
+
+    let reflect_dir = (incoming - 2.0 * incoming.dot(normal) * normal).normalize_or_zero();
+    let incident_angle = incoming.normalize_or_zero().dot(-normal).abs();
+    let bounce = incoming.length() * params.bounce_factor * incident_angle;
+    *remaining += reflect_dir * bounce;
+}
+
+fn move_vehicle_vertical(
+    spatial: &SpatialQuery,
+    params: &GameParams,
+    entity: Entity,
+    col: &Collider,
+    tf: &mut Transform,
+    veh: &mut Vehicle,
+    dt: f32,
+) {
+    apply_ground_snap(spatial, entity, tf, veh);
+
+    if veh.grounded {
+        veh.vertical_vel = 0.0;
+    } else {
+        veh.vertical_vel -= params.gravity * dt;
+    }
+    tf.translation.y += veh.vertical_vel * dt;
+    resolve_vertical_collision(spatial, entity, col, tf, veh);
+}
+
+fn resolve_vertical_collision(
+    spatial: &SpatialQuery,
+    entity: Entity,
+    col: &Collider,
+    tf: &mut Transform,
+    veh: &mut Vehicle,
+) {
+    let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
+    if let Some(hit) = spatial.cast_shape(
+        col,
+        tf.translation + Vec3::Y * (veh.half_extents.y + STEP_HEIGHT),
+        tf.rotation,
+        Dir3::NEG_Y,
+        &ShapeCastConfig {
+            compute_contact_on_penetration: true,
+            max_distance: veh.half_extents.y + STEP_HEIGHT + SKIN,
+            ..Default::default()
+        },
+        &filter,
+    ) {
+        tf.translation.y = hit.point1.y + veh.half_extents.y + SKIN;
+        veh.grounded = true;
+        veh.vertical_vel = 0.0;
+    }
+}
+
+fn apply_ground_snap(
+    spatial: &SpatialQuery,
+    entity: Entity,
+    tf: &mut Transform,
+    veh: &mut Vehicle,
+) {
+    let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
+    let grounded_now = spatial
+        .cast_ray(
+            tf.translation,
+            Dir3::NEG_Y,
+            veh.half_extents.y + STEP_HEIGHT + SKIN,
+            false,
+            &filter,
+        )
+        .is_some();
+    veh.grounded = grounded_now;
+}
+
+fn orient_to_ground(spatial: &SpatialQuery, entity: Entity, tf: &mut Transform, veh: &Vehicle) {
+    let filter = SpatialQueryFilter::default().with_excluded_entities([entity]);
+    let ground_n = spatial
+        .cast_ray(
+            tf.translation,
+            Dir3::NEG_Y,
+            veh.half_extents.y + STEP_HEIGHT + SKIN,
+            false,
+            &filter,
+        )
+        .map(|h| h.normal)
+        .unwrap_or(Vec3::Y);
+    let yaw_rot = Quat::from_rotation_y(veh.yaw);
+    let target = Quat::from_rotation_arc(Vec3::Y, ground_n) * yaw_rot;
+    const ROT_SMOOTH: f32 = 0.2;
+    tf.rotation = tf.rotation.slerp(target, ROT_SMOOTH);
+}
+
+fn vehicle_fall_reset_system(mut q: Query<(&mut Transform, &mut Vehicle)>) {
+    for (mut tf, mut veh) in &mut q {
+        if tf.translation.y < FALL_RESET_Y {
+            tf.translation = RESPAWN_POS;
+            veh.speed = 0.0;
+            veh.vertical_vel = 0.0;
+            veh.grounded = false;
+            veh.yaw = RESPAWN_YAW;
         }
     }
 }


### PR DESCRIPTION
## Summary
- enhance `Vehicle` component with physics fields
- spawn vehicles with colliders and kinematic bodies
- implement new movement and orientation systems using avian3d
- detect ground contact for wheels and apply suspension
- reset vehicles when falling too far

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c0af347308321a13efbf6833c0489