### PR TITLE
Add vehicle suspension plugin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,5 @@ pub mod chat;
 pub mod hp_text;
 pub mod vehicle;
 pub mod vehicle_systems;
+pub mod suspension;
+pub mod vehicle_plugin;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use game_demo::lap_timer::LapTimerPlugin;
 use game_demo::socket_client::SocketClientPlugin;
 use game_demo::vehicle_systems::VehiclePhysicsPlugin;
 use game_demo::chat::ChatPlugin;
-use game_demo::vehicle::VehiclePlugin;
+use game_demo::vehicle_plugin::VehiclePlugin;
 
 fn main() {
     App::new()

--- a/src/suspension.rs
+++ b/src/suspension.rs
@@ -1,0 +1,102 @@
+use bevy::prelude::*;
+use avian3d::prelude::*;
+
+/// Configuration for a wheel of the vehicle.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct WheelConfig {
+    pub pos: Vec3,
+    pub radius: f32,
+    pub mass: f32,
+    pub steer: bool,
+    pub drive: bool,
+}
+
+/// Collection of wheel configurations used when spawning the vehicle.
+#[derive(Resource, Clone)]
+pub struct WheelConfigs(pub Vec<WheelConfig>);
+
+/// Parameters controlling the suspension behaviour.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct SuspensionConfig {
+    pub rest_len: f32,
+    pub travel: f32,
+    pub stiffness: f32,
+    pub damping: f32,
+}
+
+/// Runtime suspension state for a wheel.
+#[derive(Component, Debug)]
+pub struct Suspension {
+    pub compression: f32,
+    pub contact_point: Vec3,
+    pub contact_normal: Vec3,
+    pub grounded: bool,
+    pub limit_counter: u8,
+}
+
+impl Default for Suspension {
+    fn default() -> Self {
+        Self {
+            compression: 0.0,
+            contact_point: Vec3::ZERO,
+            contact_normal: Vec3::Y,
+            grounded: false,
+            limit_counter: 0,
+        }
+    }
+}
+
+/// Applies spring and damper forces based on the current wheel compression.
+#[allow(clippy::type_complexity)]
+pub fn suspension_force_system(
+    spatial: SpatialQuery,
+    cfg: Res<SuspensionConfig>,
+    mut wheels: Query<(
+        &GlobalTransform,
+        &mut RigidBody,
+        &Parent,
+        &mut Suspension,
+    )>,
+    mut chassis: Query<&mut RigidBody>,
+) {
+    let ray_len = cfg.rest_len + cfg.travel;
+    for (tf, mut wheel_rb, parent, mut sus) in &mut wheels {
+        let Ok(mut chassis_rb) = chassis.get_mut(parent.get()) else { continue; };
+        let origin = tf.translation();
+        let dir = Vec3::NEG_Y;
+        let result = spatial.cast_ray(
+            origin,
+            Dir3::new_unchecked(dir),
+            ray_len,
+            false,
+            &SpatialQueryFilter::default(),
+        );
+        if let Some(hit) = result {
+            let compression = (cfg.rest_len - hit.distance).clamp(0.0, cfg.travel);
+            let rel_vel = wheel_rb.linear_velocity().dot(Vec3::Y)
+                - chassis_rb.linear_velocity().dot(Vec3::Y);
+            let force_mag = cfg.stiffness * compression - cfg.damping * rel_vel;
+            let force = Vec3::Y * force_mag;
+            wheel_rb.apply_force(force, ForceMode::Force);
+            chassis_rb.apply_force(-force, ForceMode::Force);
+            sus.compression = compression;
+            sus.contact_point = origin + dir * hit.distance;
+            sus.contact_normal = hit.normal;
+            sus.grounded = true;
+            if compression.abs() >= cfg.travel {
+                sus.limit_counter += 1;
+                if sus.limit_counter > 10 {
+                    warn!("suspension travel exceeded");
+                    sus.limit_counter = 0;
+                }
+            } else {
+                sus.limit_counter = 0;
+            }
+        } else {
+            sus.grounded = false;
+            sus.compression = 0.0;
+            sus.limit_counter = 0;
+        }
+    }
+}
+

--- a/src/vehicle_plugin.rs
+++ b/src/vehicle_plugin.rs
@@ -1,0 +1,141 @@
+use bevy::prelude::*;
+use avian3d::prelude::*;
+
+use crate::suspension::{WheelConfigs, WheelConfig, SuspensionConfig, Suspension, suspension_force_system};
+
+/// Revolute joint used for wheel rolling.
+#[derive(Component)]
+pub struct RollRevolute(pub RevoluteJoint);
+
+/// Revolute joint used for steering the wheel.
+#[derive(Component)]
+pub struct SteerRevolute(pub RevoluteJoint);
+
+/// Plugin spawning a simple vehicle with independent suspension.
+pub struct VehiclePlugin;
+
+impl Plugin for VehiclePlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .insert_resource(default_wheels())
+            .insert_resource(SuspensionConfig {
+                rest_len: 0.3,
+                travel: 0.2,
+                stiffness: 30000.0,
+                damping: 4500.0,
+            })
+            .add_systems(Startup, spawn_vehicle)
+            .add_systems(Update, (
+                steering_input_system,
+                drive_system,
+                suspension_force_system,
+                sync_visuals.after(suspension_force_system),
+            ));
+    }
+}
+
+fn default_wheels() -> WheelConfigs {
+    WheelConfigs(vec![
+        WheelConfig { pos: Vec3::new( 1.0, 0.0, 1.5), radius: 0.5, mass: 20.0, steer: true,  drive: false },
+        WheelConfig { pos: Vec3::new(-1.0, 0.0, 1.5), radius: 0.5, mass: 20.0, steer: true,  drive: false },
+        WheelConfig { pos: Vec3::new( 1.0, 0.0,-1.5), radius: 0.5, mass: 20.0, steer: false, drive: true  },
+        WheelConfig { pos: Vec3::new(-1.0, 0.0,-1.5), radius: 0.5, mass: 20.0, steer: false, drive: true  },
+    ])
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_vehicle(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    wheels: Res<WheelConfigs>,
+    sus_cfg: Res<SuspensionConfig>,
+) {
+    let chassis = commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(Cuboid::new(2.0, 0.5, 4.0))),
+            material: materials.add(Color::srgb(0.2, 0.2, 0.8)),
+            ..default()
+        })
+        .insert(RigidBody::Dynamic)
+        .insert(Collider::cuboid(1.0, 0.25, 2.0))
+        .id();
+
+    for cfg in wheels.0.iter() {
+        let wheel = commands
+            .spawn(PbrBundle {
+                mesh: meshes.add(Mesh::from(Cylinder {
+                    radius: cfg.radius,
+                    half_height: 0.15,
+                })),
+                material: materials.add(Color::srgb(0.1, 0.1, 0.1)),
+                transform: Transform::from_translation(cfg.pos),
+                ..default()
+            })
+            .insert(RigidBody::Dynamic)
+            .insert(Collider::cylinder(cfg.radius, 0.15))
+            .insert(Suspension::default())
+            .insert(*cfg)
+            .id();
+
+        commands.entity(wheel).insert(PrismaticJoint::new(
+            chassis,
+            Vec3::Y,
+            -sus_cfg.travel,
+            sus_cfg.travel,
+        ));
+        commands.entity(wheel).insert(RollRevolute(RevoluteJoint::new(chassis, Vec3::X)));
+        if cfg.steer {
+            commands.entity(wheel).insert(SteerRevolute(RevoluteJoint::new(chassis, Vec3::Y)));
+        }
+    }
+}
+
+fn steering_input_system(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut joints: Query<&mut SteerRevolute>,
+) {
+    let steer = if keys.pressed(KeyCode::KeyA) {
+        0.5
+    } else if keys.pressed(KeyCode::KeyD) {
+        -0.5
+    } else {
+        0.0
+    };
+
+    for mut joint in &mut joints {
+        joint.0.set_motor_target(steer);
+    }
+}
+
+fn drive_system(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut joints: Query<(&mut RollRevolute, &WheelConfig)>,
+) {
+    let throttle = if keys.pressed(KeyCode::KeyW) {
+        50.0
+    } else if keys.pressed(KeyCode::KeyS) {
+        -50.0
+    } else {
+        0.0
+    };
+
+    for (mut joint, cfg) in &mut joints {
+        if cfg.drive {
+            joint.0.add_motor_torque(throttle);
+        }
+    }
+}
+
+fn sync_visuals(
+    wheels: Query<(&GlobalTransform, &Parent), With<Suspension>>,
+    mut visuals: Query<&mut Transform, Without<RigidBody>>,
+) {
+    for (tf, parent) in &wheels {
+        if let Ok(mut v_tf) = visuals.get_mut(parent.get()) {
+            v_tf.translation = tf.translation();
+            v_tf.rotation = tf.rotation();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add components and systems for physics suspension
- implement new `VehiclePlugin` for spawning the car and handling input
- expose the plugin through `lib.rs` and use it in `main.rs`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fea14ec248321b0569650533caa3e