### PR TITLE
Fix unconstrained generic in VehiclePlugin

### DIFF
--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -32,7 +32,7 @@ pub struct Wheel {
 
 pub struct VehiclePlugin;
 
-impl<Parent> Plugin for VehiclePlugin {
+impl Plugin for VehiclePlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, spawn_vehicle)
             .add_systems(
@@ -41,7 +41,7 @@ impl<Parent> Plugin for VehiclePlugin {
                     vehicle_toggle_system,
                     vehicle_input_system,
                     vehicle_move_system.after(vehicle_input_system),
-                    wheel_update_system::<Parent>.after(vehicle_move_system),
+                    wheel_update_system.after(vehicle_move_system),
                     sync_player_to_vehicle_system,
                 ),
             );
@@ -190,7 +190,7 @@ fn vehicle_move_system(
     }
 }
 
-fn wheel_update_system<Parent: bevy::prelude::Component>(
+fn wheel_update_system(
     time: Res<Time>,
     vehicles: Query<&Vehicle>,
     mut wheels: Query<(&Parent, &mut Transform, &mut Wheel)>,


### PR DESCRIPTION
## Summary
- remove unused `Parent` generic from `VehiclePlugin`
- simplify `wheel_update_system` to use Bevy's `Parent` component directly

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68b25568eea883218794d593db2c4917